### PR TITLE
Modify cqn implementation

### DIFF
--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
@@ -97,6 +97,12 @@ ALL_USED_IDs = c(ALL_USED_IDs, COVAR_ID)
 COVARIATES = downloadFile(COVAR_ID) %>% 
   tibble::column_to_rownames(var = "SampleID")
 
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)]
+
+
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Reported_Gender", "LibraryBatch", "Dx", "RibozeroBatch", "FlowcellBatch")
 COVARIATES[,FactorCovariates] = lapply(COVARIATES[,FactorCovariates], factor)
@@ -107,6 +113,7 @@ ContCovariates <- c("ageOfDeath", "PMI", "RIN", "MappedReads", "IntragenicRate",
 COVARIATES[,ContCovariates] = lapply(COVARIATES[,ContCovariates], function(x){
   x = as.numeric(as.character(gsub('[\\,\\%]','',x)))
 })
+
 
 # Set covariates to adjust for from model selection
 adjust.covars <- c("Dx", "ageOfDeath", "RIN", "IntronicRate", "IntragenicRate", "IntergenicRate")

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
@@ -482,7 +482,7 @@ ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
                    executed = thisFile, activityDescription = activityDescription)
 synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
 
-# Store contrasts
+# Store formula
 saveRDS(formula, file = 'CMC_DLPFC_Dx_formula.rds')
 ADJ_OBJ = File('CMC_DLPFC_Dx_formula.rds',
                name = 'formula', 

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
@@ -288,7 +288,7 @@ L3 = variancePartition::getContrast(exprObj = VOOM.GENE_EXPRESSION,
                                    coefficient = c("DxSCZ", "DxOther"))
 
 # Manually set comparison of SCZ-Other to Control
-L = cbind(L1, L2, L3, data.frame(L4 = c(1, -0.5, -0.5, 0, 0, 0, 0, 0, 0)))
+L = cbind(L1, L2, L3, data.frame(L4 = c(1, -0.5, -0.5, 0, 0, 0, 0, 0)))
 
 contrast <- c(glue::glue_collapse(names(L1[L1 != 0]), "-"), 
               glue::glue_collapse(names(L2[L2 != 0]), "-"),

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
@@ -67,7 +67,7 @@ activityDescription = 'Differential Expression - Dx';
 thisFileName <- 'HBCC_DLPFC_DE_Diagnosis.Rmd'
 
 # Github link
-thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='master')
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
 thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
@@ -314,7 +314,7 @@ backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
 
 # Get gene lengths
 counts = 'syn21886235'
-ALL_USED_IDs = counts
+ALL_USED_IDs = c(ALL_USED_IDs, counts)
 counts = downloadFile(counts) %>% data.frame()
 gene_lengths = counts[,c("Geneid", "Length")] %>% 
   dplyr::rename(gene_id = Geneid)
@@ -396,6 +396,8 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 
 multiplot(plotlist = pl, cols = 3)
 ```
+### Source Code
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
@@ -268,7 +268,8 @@ gc()
 ### Differential expression analysis (SCZ - Control - Other)
 Genes that are differentially expressed at an FDR <= 0.05 are:
 ```{r set-formula}
-formula <- glue::glue("~ 0 + ", glue::glue_collapse(adjust.covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))    
+adjust.covars <- glue::glue('scale({adjust.covars})')[-1]
+formula <- glue::glue("~ 0 + Dx + ", glue::glue_collapse(adjust.covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))    
 ```
 
 `r formula`

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
@@ -6,9 +6,6 @@ output: html_document
 ---
 
 ```{r knit2synapse, eval=FALSE}
-ml git pandoc
-rmarkdown::render("individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd")
-
 library(synapser)
 library(knit2synapse)
 
@@ -16,8 +13,7 @@ synLogin()
 
 knit2synapse::createAndKnitToFolderEntity(file = "individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd",
                                  parentId ="syn22050019",
-                                 folderName = "Differential Expression - Dx",
-                                 knitmd=FALSE)
+                                 folderName = "Differential Expression - Dx")
 ```
 
 ```{r libs, echo=FALSE, warning=FALSE, message=FALSE, include=FALSE}
@@ -39,6 +35,7 @@ library(edgeR)
 library(synapser)
 library(knitr)
 library(githubr) # get the package from devtools::install_github('brian-bot/githubr')
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
 
 synLogin()
 
@@ -121,16 +118,15 @@ random_effect <- c("Reported_Gender")
 
 ```{r iterative.normalisation, results='asis'}
 writeLines(glue::glue('Using following covariates in the model:',
-                 glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
-                 ' as fixed effects and',
-                 glue::glue_collapse(random_effect, sep = ", ", last = " and "),' chosen as random effects'))
+                 glue::glue_collapse(c(adjust.covars, random_effect), sep = ", ", last = " and "),
+                 ' as fixed effects.'))
 
 col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
   dplyr::summarise_all(class) %>% 
   tidyr::gather(variable, class)
 
 # Scale continuous variables
-adjust.covars = sapply(1:length(col_type$class), function(i){
+covars = sapply(1:length(col_type$class), function(i){
   switch(col_type$class[i], 
     "factor" = paste0(col_type$variable[i]),
     "numeric" = paste0('scale(', col_type$variable[i], ')')
@@ -138,11 +134,20 @@ adjust.covars = sapply(1:length(col_type$class), function(i){
   })
 
 # Post adjusted formula
-formula <- glue::glue("~ ", glue::glue_collapse(adjust.covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))    
-
+formula <- formula(glue::glue("~", glue::glue_collapse(covars, sep = " + ")))
+design <- model.matrix(formula, COVARIATES)
+  
 # Estimate voom weights with DREAM
 geneExpr = DGEList(NEW.COUNTS)
-geneExpr = edgeR::calcNormFactors(geneExpr)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
 
 VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
                                                                formula = formula,
@@ -174,8 +179,7 @@ setMethod("plot", signature(x="EList", y="missing"),
 plot(VOOM.GENE_EXPRESSION)
 
 # Fit linear model using new weights and new design
-VOOM.GENE_EXPRESSION$E = CQN.GENE_EXPRESSION
-ADJUSTED.FIT = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION,
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
                                         formula = formula,
                                         data = COVARIATES,
                                         computeResiduals = TRUE)
@@ -469,7 +473,6 @@ ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
                    executed = thisFile, activityDescription = activityDescription)
 synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
 
-
 # Store contrasts
 saveRDS(formula, file = 'CMC_DLPFC_Dx_formula.rds')
 ADJ_OBJ = File('CMC_DLPFC_Dx_formula.rds',
@@ -478,10 +481,4 @@ ADJ_OBJ = File('CMC_DLPFC_Dx_formula.rds',
 ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
                    executed = thisFile, activityDescription = activityDescription)
 synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
-
 ```
-
-
-
-
-

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Diagnosis.Rmd
@@ -82,8 +82,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22082460"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22082459"
@@ -100,8 +99,8 @@ COVARIATES = downloadFile(COVAR_ID) %>%
 # Remove ages under 17
 COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
 NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
-CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)]
-
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Reported_Gender", "LibraryBatch", "Dx", "RibozeroBatch", "FlowcellBatch")

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_DxSex.Rmd
@@ -1,0 +1,494 @@
+---
+title: "Differential Expression - HBCC - DLPFC - Dx - Sex"
+author: "Kelsey Montgomery, Gabriel Hoffman, Thanneer Perumal"
+date: "`r date()`"
+output: html_document
+---
+
+```{r knit2synapse, eval=FALSE}
+library(synapser)
+library(knit2synapse)
+
+synLogin()
+
+knit2synapse::createAndKnitToFolderEntity(file = "individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_DxSex.Rmd",
+                                 parentId ="syn22050019",
+                                 folderName = "Differential Expression - Dx - Sex")
+```
+
+```{r libs, echo=FALSE, warning=FALSE, message=FALSE, include=FALSE}
+## Load required libraries
+library(CovariateAnalysis) # get the package from devtools::install_github('th1vairam/CovariateAnalysis@dev')
+library(data.table)
+library(tidyr)
+library(plyr)
+library(dplyr)
+library(stringr)
+library(R.utils)
+library(ggplot2)
+library(limma)
+library(psych)
+library(lme4)
+library(biomaRt)
+library(variancePartition)
+library(edgeR)
+library(synapser)
+library(knitr)
+library(githubr) # get the package from devtools::install_github('brian-bot/githubr')
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
+
+synLogin()
+
+library(foreach)
+library(future)
+library(BiocParallel)
+
+# See dream documentation to customize parallel processing       http://bioconductor.org/packages/release/bioc/vignettes/variancePartition/inst/doc/dream.html#parallel-processing
+param = SnowParam((availableCores()-2)/2, "SOCK", progressbar=TRUE)
+
+register(param)
+
+options(xtable.type="html")
+
+knitr::opts_chunk$set(
+  echo=FALSE,
+  warning=FALSE,
+  message=FALSE,
+  error = FALSE,
+  tidy = FALSE,
+  cache = TRUE)
+```
+
+```{r synapse.parameters, include=FALSE, cache=FALSE}
+parentId = 'syn22050019';
+activityName = 'Differential Expression';
+activityDescription = 'Differential Expression - Dx_Sex';
+
+thisFileName <- 'HBCC_DLPFC_DE_DxSex.Rmd'
+
+# Github link
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis',thisFileName))
+```
+
+### Data download
+#### Obtain filtered and CQN normalized counts
+```{r download.data, cache=TRUE}
+downloadFile <- function(id){
+  fread(synGet(id)$path, data.table = F)
+}
+
+# Download CQN counts
+CQN_ID = "syn22082460"
+ALL_USED_IDs = c(CQN_ID)
+CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
+  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
+  data.matrix()
+  
+# Download filtered counts
+COUNTS_ID = "syn22082459"
+ALL_USED_IDs = c(ALL_USED_IDs, COUNTS_ID)
+NEW.COUNTS = downloadFile(COUNTS_ID) %>% 
+  tibble::column_to_rownames(var = "ensembl_gene_id")
+  
+# Get covariates
+COVAR_ID = "syn22082458"
+ALL_USED_IDs = c(ALL_USED_IDs, COVAR_ID)
+COVARIATES = downloadFile(COVAR_ID) %>% 
+  tibble::column_to_rownames(var = "SampleID")
+
+# Set variable class
+FactorCovariates <- c("Individual_ID", "Reported_Gender", "LibraryBatch", "Dx", "RibozeroBatch", "FlowcellBatch")
+COVARIATES[,FactorCovariates] = lapply(COVARIATES[,FactorCovariates], factor)
+
+ContCovariates <- c("ageOfDeath", "PMI", "RIN", "MappedReads", "IntragenicRate", "IntronicRate", "IntergenicRate",
+                    "GenesDetected", "ExpProfEfficiency", "rRNARate", "TotalReads","AlignmentRate", 
+                    "EV.1", "EV.2", "EV.3", "EV.4", "EV.5")
+COVARIATES[,ContCovariates] = lapply(COVARIATES[,ContCovariates], function(x){
+  x = as.numeric(as.character(gsub('[\\,\\%]','',x)))
+})
+
+# Set covariates to adjust for from model selection
+interaction <- c("Dx", "Reported_Gender")
+adjust.covars <- c("ageOfDeath", "RIN", "IntronicRate", "IntragenicRate", "IntergenicRate")
+```
+
+### Normalisation - Dx*Sex
+1. Dx*Sex is chosen as the primary variable of interest
+
+```{r iterative.normalisation, results='asis'}
+writeLines(glue::glue('Using following covariates in the model:',
+                      glue::glue_collapse(interaction, sep = ", "),
+                      ', ',
+                      glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
+                      ' as fixed effects.'))
+
+col_type <- dplyr::select(COVARIATES, c(adjust.covars)) %>%
+  dplyr::summarise_all(class) %>% 
+  tidyr::gather(variable, class)
+
+# Scale continuous variables
+adjust.covars = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0(col_type$variable[i]),
+    "numeric" = paste0('scale(', col_type$variable[i], ')')
+  )
+  })
+
+# Post adjusted formula
+formula <- formula(glue::glue("~ ", glue::glue_collapse(interaction, sep = "*")," + ", glue::glue_collapse(adjust.covars, sep = " + ")))
+design <- model.matrix(formula, COVARIATES)
+ 
+# Estimate voom weights with DREAM
+geneExpr = DGEList(NEW.COUNTS)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
+
+VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
+                                                               formula = formula,
+                                                               data = COVARIATES,
+                                                               save.plot = TRUE)
+
+# How to plot a voom object if save.plot=TRUE
+# Set plot generic to voom result EList
+#' @export
+setMethod("plot", signature(x="EList", y="missing"),
+  function(x,  y, ...){
+    if( is.null(x$voom.xy) || is.null(x$voom.line)){
+        stop("x does not contain the trend information.\nvoom() must be run with save.plot=TRUE")
+    }
+    # points
+    df = data.frame(x = x$voom.xy$x,
+                    y = x$voom.xy$y)
+    # trend line
+    df.line = data.frame(x = x$voom.line$x,
+                        y = x$voom.line$y)
+    ggplot(df, aes(x,y)) + geom_point(size=.1) + theme_bw(15) + 
+      theme(aspect.ratio=1, plot.title = element_text(hjust = 0.5)) + 
+      geom_line(data=df.line, aes(x,y), color="red") + xlab(bquote(log[2](count + 0.5))) + 
+      ylab(expression( sqrt("standard deviation"))) + ggtitle("Voom: Mean-variance trend") + 
+      ylim(0, max(df$y))
+  }
+)
+  
+plot(VOOM.GENE_EXPRESSION)
+
+# Fit linear model using new weights and new design
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
+                                        formula = formula,
+                                        data = COVARIATES,
+                                        computeResiduals = TRUE)
+
+# Model categorical variables as random to report variance fractions
+formula_for_variance_fractions = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0('(1|', col_type$variable[i], ')'),
+    "numeric" = paste0('scale(', col_type$variable[i], ')')
+  )
+  })
+
+# Manually specify interaction
+interaction <- c(interaction, "Dx:Reported_Gender")
+interaction_variance <- glue::glue("(1|{interaction})")
+all <- c(interaction_variance, formula_for_variance_fractions)
+
+formula_for_variance_fractions <- glue::glue("~ ", glue::glue_collapse(all, sep = " + "))
+
+violin_plot <- variancePartition::fitExtractVarPartModel(VOOM.GENE_EXPRESSION,
+                                                         formula = formula_for_variance_fractions,
+                                                         data = COVARIATES)
+
+plotVarPart(sortCols(violin_plot))
+
+# Residuals after normalisation
+RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
+```
+`r formula`
+### Residual calculation
+Calculate weighted residuals and add back "Dx:Sex" to the residuals
+```{r varsToAddBack}
+# Add variable of interest back to the residuals
+varsToAddIn = grep("DxOther:Reported_GenderMale", "DxSCZ:Reported_GenderMale", colnames(ADJUSTED.FIT$design), value = T)
+RESIDUAL.GENE_EXPRESSION = RESIDUAL.GENE_EXPRESSION +
+  ADJUSTED.FIT$coefficients[,varsToAddIn] %*% t(ADJUSTED.FIT$design[,varsToAddIn])
+```
+
+### Coexpression of residual expression 
+```{r coexp2, cache=FALSE, fig.height=5, fig.width=5}
+cr = cor(t(RESIDUAL.GENE_EXPRESSION))
+hist(cr, main = 'Distribution of correlation between genes', xlab = 'Correlation')
+```
+
+### Clustering residual data
+```{r decompse.normalise.data2, fig.height=8, fig.width=8, results='asis'}
+# Find principal components of expression to plot
+PC <- prcomp(RESIDUAL.GENE_EXPRESSION, scale.=T, center = T)
+
+# Plot first 4 PCs
+plotdata <- data.frame(SampleID=rownames(PC$rotation), 
+                       PC1=PC$rotation[,1], 
+                       PC2=PC$rotation[,2])
+
+plotdata <- left_join(plotdata, rownameToFirstColumn(COVARIATES, 'SampleID')) %>% 
+  dplyr::mutate(Tissue = "DLPFC")
+
+p <- ggplot(plotdata, aes(x=PC1, y=PC2))
+p <- p + geom_point(aes(shape=Tissue, size=ageOfDeath))
+p <- p + theme_bw() + theme(legend.position="right") + facet_grid(Tissue~., scales = 'free_y')
+p
+```
+
+```{r decompose.normalise.data2.1, fig.height=8, fig.width=12, results='asis'}
+# Eucledian tree based analysis
+COVARIATES.tmp = data.matrix(COVARIATES[,c('Dx', 'Reported_Gender'), drop = FALSE])
+
+tree = hclust(as.dist(t(RESIDUAL.GENE_EXPRESSION)))
+cols = WGCNA::labels2colors(COVARIATES.tmp);
+
+WGCNA::plotDendroAndColors(tree, 
+                           colors = cols, 
+                           dendroLabels = FALSE, 
+                           abHeight = 0.80, 
+                           main = "Sample dendrogram",
+                           groupLabels = colnames(COVARIATES.tmp[,c('Dx','Reported_Gender'), drop = FALSE]))
+```
+
+```{r temp1, include=F}
+dev.off()
+gc()
+```
+
+### Differential expression analysis (SCZ - Control - Other)
+Genes that are differentially expressed at an FDR <= 0.05 are:
+```{r set-formula}
+formula <- glue::glue("~ 0 + Dx_Sex + ", glue::glue_collapse(adjust.covars, sep = " + "))
+```
+
+`r formula`
+
+Dx_Sex is 6 levels, SCZ_Female, SCZ_Male, Other_Female, Other_Male, Control_Female, Control_Male
+
+```{r diffExp, fig.height=10, fig.width=15}
+# Test Dx-Sex
+COVARIATES <- COVARIATES %>%
+  tibble::rownames_to_column(var = "samples") %>% 
+  tidyr::unite("Dx_Sex",
+               dplyr::all_of(c("Dx", "Reported_Gender")),
+               remove = TRUE) %>% 
+  dplyr::mutate(`Dx_Sex` = as.factor(`Dx_Sex`)) %>% 
+  tibble::column_to_rownames(var = "samples")
+
+L1 = variancePartition::getContrast(exprObj = VOOM.GENE_EXPRESSION, 
+                                   formula = formula, 
+                                   data = COVARIATES, 
+                                   coefficient = c("Dx_SexControl_Male", "Dx_SexControl_Female"))
+L2 = c(1, -1, 0, 0, -1, 1, 0, 0, 0, 0, 0)
+L3 = c(1, -1, -1, 1, 0, 0, 0, 0, 0, 0, 0)
+
+# Manually set comparison between SCZ+Other vs. Control 
+L = cbind(L1, L2, L3)
+
+contrast <- c(glue::glue_collapse(names(L1[L1 != 0]), "-"), 
+              glue::glue("Dx_SexSCZ_MaleDx_SexControl_Male-Dx_SexSCZ_FemaleDx_SexControl_Female"),
+              glue::glue("Dx_SexOther_MaleDx_SexControl_Male-Dx_SexOther_FemaleDx_SexControl_Female")
+)
+
+# Visualize contrast matrix
+plotContrasts(L) 
+
+# Fit contrast
+FIT.CONTR = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION,
+                                     formula = formula,
+                                     data = COVARIATES,
+                                     L = L,
+                                     suppressWarnings = TRUE)
+
+# Get background genes 
+backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
+  dplyr::mutate(id = gene_id) %>%
+  tidyr::separate(id, c('ensembl_gene_id','position'), sep = '\\.')
+
+# Get gene lengths
+counts = 'syn21886235'
+ALL_USED_IDs = c(counts, ALL_USED_IDs)
+counts = downloadFile(counts) %>% data.frame()
+gene_lengths = counts[,c("Geneid", "Length")] %>% 
+  dplyr::rename(gene_id = Geneid)
+rm(counts)
+
+# Define biomart object
+mart <- biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL",
+                host = "uswest.ensembl.org", # Ensembl Release 99 (January 2020)
+                dataset = "hsapiens_gene_ensembl")
+
+# Query biomart
+Ensemble2HGNC <- getBM(attributes = c("ensembl_gene_id", "hgnc_symbol", 
+                                      "percentage_gene_gc_content", "gene_biotype", 
+                                      "chromosome_name"),
+                       filters = "ensembl_gene_id", 
+                       values = backgroundGenes$ensembl_gene_id,
+                       mart = mart)
+
+FIT.CONTR <- eBayes(FIT.CONTR)
+
+# Get differential expression
+DE = lapply(glue::glue("L{1:3}"), function(i, FIT){
+  topTable(FIT, coef=i, number = Inf) %>%
+    rownameToFirstColumn('gene_id') %>% 
+    left_join(backgroundGenes)
+}, FIT.CONTR) 
+names(DE) <- contrast
+
+DE = DE %>% 
+  rbindlist(idcol = 'Comparison') %>%
+  dplyr::mutate(Comparison = gsub('Dx_Sex','',Comparison),
+                Direction = logFC/abs(logFC),
+                Direction = factor(Direction, c(-1,1), c('-1' = 'DOWN', '1' = 'UP')),
+                Direction = as.character(Direction)) %>%
+  tidyr::separate(Comparison, into = c('ref.state','to.state'), sep = '-') %>%
+  tidyr::unite(Comparison, `ref.state`, `to.state`, sep = '_vs_') %>%
+  left_join(Ensemble2HGNC) %>%
+  left_join(gene_lengths)
+DE$Direction[DE$adj.P.Val > 0.05 | abs(DE$logFC) < log2(1.2)] = 'NONE'
+
+tmp = DE %>%
+  dplyr::filter(adj.P.Val <= 0.05) %>%
+  dplyr::select(ensembl_gene_id, Comparison) %>%
+  group_by(Comparison) %>%
+  dplyr::summarise(FDR_0_05 = length(unique(ensembl_gene_id)))
+
+tmp1 = DE %>%
+  dplyr::filter(adj.P.Val <= 0.05, abs(logFC) >= log2(1.2)) %>%
+  dplyr::select(ensembl_gene_id, Comparison) %>%
+  group_by(Comparison) %>%
+  dplyr::summarise(FDR_0_05_FC_1.2 = length(unique(ensembl_gene_id)))
+
+kable(full_join(tmp,tmp1))
+
+p = ggplot(DE, aes(y = -log10(adj.P.Val), x = logFC, color = Direction)) + geom_point() + xlim(c(-1,1))
+p = p + scale_color_manual(values = c('green','grey','red')) + theme_bw() %+replace% theme(legend.position = 'top')
+p = p + facet_grid(.~Comparison, scales = 'fixed')
+p
+```
+
+### Associate differential expression results with gc content, gene length and average expression
+```{r associate.de, fig.height=10, fig.width=15}
+pl = list()
+pl[[1]] = ggplot(DE %>% 
+                   arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = log10(Length), y = logFC, color = Direction)) + geom_point() 
+pl[[1]] = pl[[1]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = log10(Length), y = logFC))
+pl[[1]] = pl[[1]] + scale_color_manual(values = c('green','grey','red'))
+pl[[1]] = pl[[1]] + theme(legend.position = 'top')
+
+pl[[2]] = ggplot(DE %>% 
+                   arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = percentage_gene_gc_content, y = logFC, color = Direction)) + geom_point()
+pl[[2]] = pl[[2]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = percentage_gene_gc_content, y = logFC))
+pl[[2]] = pl[[2]] + scale_color_manual(values = c('green','grey','red'))
+pl[[2]] = pl[[2]] + theme(legend.position = 'top')
+
+pl[[3]] = ggplot(DE %>% 
+                    arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = AveExpr, y = logFC, color = Direction)) + geom_point()
+pl[[3]] = pl[[3]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = AveExpr, y = logFC))
+pl[[3]] = pl[[3]] + scale_color_manual(values = c('green','grey','red'))
+pl[[3]] = pl[[3]] + theme(legend.position = 'top')
+
+multiplot(plotlist = pl, cols = 3)
+```
+### Source Code
+`r thisFile`
+
+### Store files in synapse
+```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}
+# Set annotations
+all.annotations = list(
+  dataType = 'geneExpression',
+  dataSubtype = 'processed',
+  assay	 = 'rnaSeq',
+  
+  tissue	= 'dorsolateral prefrontal cortex', 
+  study = 'CMC', 
+
+  species = 'Human',
+  consortium	= 'CMC',
+   
+  analysisType	= "data normalization",
+  
+  transcriptNormalizationMethod	= 'CQN',
+  transcriptQuantificationMethod = 'featureCounts',
+  referenceSet = 'GRCh38'
+)
+
+# Code
+CODE <- Folder(name = "Differential Expression - Dx - Sex", parentId = parentId)
+CODE <- synStore(CODE)
+
+# Store residual gene expression for network analysis
+RESIDUAL.GENE_EXPRESSION %>%
+  rownameToFirstColumn('ensembl_gene_id') %>%
+  write.table(file = 'CMC_DLPFC_Dx_Sex_netResidualExpression.tsv', sep = '\t', row.names=F, quote=F)
+nEXP_OBJ = File('CMC_DLPFC_Dx_Sex_netResidualExpression.tsv', 
+                name = 'Dx_Sex Normalised, covariates removed residual expression (for network analysis)', 
+                parentId = CODE$properties$id)
+nEXP_OBJ = synStore(nEXP_OBJ, used = ALL_USED_IDs, activityName = activityName, 
+                    executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(nEXP_OBJ, annotations = all.annotations)
+
+# Store differential expression results
+write.table(DE, file = 'CMC_DLPFC_Dx_Sex_DiffExpression.tsv', sep = '\t', row.names=F, quote=F)
+DEXP_OBJ = File('CMC_DLPFC_Dx_Sex_DiffExpression.tsv', 
+                name = 'Differential Expression Results (Dx_Sex)', 
+                parentId = CODE$properties$id)
+DEXP_OBJ = synStore(DEXP_OBJ, used = ALL_USED_IDs, activityName = activityName, 
+                    executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(DEXP_OBJ, annotations = all.annotations)
+
+# Store adjusted fit linear mixed model object as RDS - Dx_Sex
+saveRDS(ADJUSTED.FIT, file = 'CMC_DLPFC_Dx_Sex_dream-output.rds')
+ADJ_OBJ = File('CMC_DLPFC_Dx_Sex_dream-output.rds',
+               name = 'Dream Output object - Dx_Sex', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store variancePartition
+saveRDS(sortCols(violin_plot), file = 'CMC_DLPFC_Dx_Sex_variancePartition.rds')
+ADJ_OBJ = File('CMC_DLPFC_Dx_Sex_variancePartition.rds',
+               name = 'Variance Partition result', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store voom object
+saveRDS(VOOM.GENE_EXPRESSION, file = 'CMC_DLPFC_Dx_Sex_voom.rds')
+ADJ_OBJ = File('CMC_DLPFC_Dx_Sex_voom.rds',
+               name = 'voom object', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store contrasts
+saveRDS(L, file = 'CMC_DLPFC_Dx_Sex_contrasts.rds')
+ADJ_OBJ = File('CMC_DLPFC_Dx_Sex_contrasts.rds',
+               name = 'contrast matrix', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store formula
+saveRDS(formula, file = 'CMC_DLPFC_Dx_Sex_formula.rds')
+ADJ_OBJ = File('CMC_DLPFC_Dx_Sex_formula.rds',
+               name = 'formula', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+```

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_DxSex.Rmd
@@ -405,7 +405,7 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 multiplot(plotlist = pl, cols = 3)
 ```
 ### Source Code
-`r thisFile`
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_DxSex.Rmd
@@ -82,8 +82,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22082460"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22082459"
@@ -96,6 +95,12 @@ COVAR_ID = "syn22082458"
 ALL_USED_IDs = c(ALL_USED_IDs, COVAR_ID)
 COVARIATES = downloadFile(COVAR_ID) %>% 
   tibble::column_to_rownames(var = "SampleID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Reported_Gender", "LibraryBatch", "Dx", "RibozeroBatch", "FlowcellBatch")

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_DxSex.Rmd
@@ -68,7 +68,7 @@ thisFileName <- 'HBCC_DLPFC_DE_DxSex.Rmd'
 
 # Github link
 thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
-thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis',thisFileName))
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
 ### Data download
@@ -213,7 +213,7 @@ plotVarPart(sortCols(violin_plot))
 # Residuals after normalisation
 RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
 ```
-`r formula`
+
 ### Residual calculation
 Calculate weighted residuals and add back "Dx:Sex" to the residuals
 ```{r varsToAddBack}

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Sex.Rmd
@@ -82,8 +82,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22082460"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22082459"
@@ -96,6 +95,12 @@ COVAR_ID = "syn22082458"
 ALL_USED_IDs = c(ALL_USED_IDs, COVAR_ID)
 COVARIATES = downloadFile(COVAR_ID) %>% 
   tibble::column_to_rownames(var = "SampleID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Reported_Gender", "LibraryBatch", "Dx", "RibozeroBatch", "FlowcellBatch")

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Sex.Rmd
@@ -67,7 +67,7 @@ activityDescription = 'Differential Expression - Sex';
 thisFileName <- 'HBCC_DLPFC_DE_Sex.Rmd'
 
 # Github link
-thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='master')
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
 thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
@@ -295,7 +295,7 @@ backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
 
 # Get gene lengths
 counts = 'syn21886235'
-ALL_USED_IDs = counts
+ALL_USED_IDs = c(ALL_USED_IDs, counts)
 counts = downloadFile(counts) %>% data.frame()
 gene_lengths = counts[,c("Geneid", "Length")] %>% 
   dplyr::rename(gene_id = Geneid)
@@ -379,6 +379,8 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 
 multiplot(plotlist = pl, cols = 3)
 ```
+### Source Code
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Sex.Rmd
@@ -208,6 +208,8 @@ plotVarPart(sortCols(violin_plot))
 RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
 ```
 
+`r glue::glue_collapse(formula)`
+
 ### Residual calculation
 Calculate weighted residuals and add back "Sex" to the residuals
 ```{r varsToAddBack}

--- a/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Sex.Rmd
@@ -6,9 +6,6 @@ output: html_document
 ---
 
 ```{r knit2synapse, eval=FALSE}
-ml git pandoc
-rmarkdown::render("individual-cohorts/split_by_analysis/HBCC_DLPFC_DE_Sex.Rmd")
-
 library(synapser)
 library(knit2synapse)
 
@@ -38,6 +35,7 @@ library(edgeR)
 library(synapser)
 library(knitr)
 library(githubr) # get the package from devtools::install_github('brian-bot/githubr')
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
 
 synLogin()
 
@@ -117,7 +115,7 @@ adjust.covars <- c("Sex", "Dx", "ageOfDeath", "RIN", "IntronicRate", "Intragenic
 ```
 
 ### Normalisation - Sex
-1. Sex is chosen as the primary variable of interest (i.e., covariate adjustments is conditioned on diagnosis)
+1. Sex is chosen as the primary variable of interest
 
 ```{r iterative.normalisation, results='asis'}
 writeLines(glue::glue('Using following covariates in the model:',
@@ -137,11 +135,18 @@ adjust.covars = sapply(1:length(col_type$class), function(i){
   })
 
 # Post adjusted formula
-formula <- glue::glue("~ ", glue::glue_collapse(adjust.covars, sep = " + "))    
-
+formula <- formula(glue::glue("~ ", glue::glue_collapse(adjust.covars, sep = " + ")))    
+design <- model.matrix(formula, COVARIATES)
+ 
 # Estimate voom weights with DREAM
 geneExpr = DGEList(NEW.COUNTS)
-geneExpr = edgeR::calcNormFactors(geneExpr)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
 
 VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
                                                                formula = formula,
@@ -173,8 +178,7 @@ setMethod("plot", signature(x="EList", y="missing"),
 plot(VOOM.GENE_EXPRESSION)
 
 # Fit linear model using new weights and new design
-VOOM.GENE_EXPRESSION$E = CQN.GENE_EXPRESSION
-ADJUSTED.FIT = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION,
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
                                         formula = formula,
                                         data = COVARIATES,
                                         computeResiduals = TRUE)

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Diagnosis.Rmd
@@ -64,11 +64,11 @@ parentId = 'syn22084347';
 activityName = 'Differential Expression';
 activityDescription = 'Differential Expression - Dx';
 
-thisFileName <- 'HBCC_dsACC_DE.Rmd'
+thisFileName <- 'HBCC_dsACC_DE_Diagnosis.Rmd'
 
 # Github link
-thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='master')
-thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/',thisFileName))
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
 ### Data download
@@ -312,7 +312,7 @@ backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
 
 # Get gene lengths
 counts = 'syn21867866'
-ALL_USED_IDs = counts
+ALL_USED_IDs = c(ALL_USED_IDs, counts)
 counts = downloadFile(counts) %>% data.frame()
 gene_lengths = counts[,c("Geneid", "Length")] %>% 
   dplyr::rename(gene_id = Geneid)
@@ -394,6 +394,8 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 
 multiplot(plotlist = pl, cols = 3)
 ```
+### Source Code
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Diagnosis.Rmd
@@ -82,8 +82,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22086076"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22086075"
@@ -96,6 +95,12 @@ COVAR_ID = "syn22086074"
 ALL_USED_IDs = c(ALL_USED_IDs, COVAR_ID)
 COVARIATES = downloadFile(COVAR_ID) %>% 
   tibble::column_to_rownames(var = "SampleID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Reported_Gender", "Dx", "IsolationBatch")

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Diagnosis.Rmd
@@ -123,7 +123,7 @@ random_effect <- c("Reported_Gender", "IsolationBatch")
 
 ```{r iterative.normalisation, results='asis'}
 writeLines(glue::glue('Using following covariates in the model:',
-                 glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
+                 glue::glue_collapse(c(adjust.covars,random_effect), sep = ", ", last = " and "),
                  ' as fixed effects.'))
 
 scaled_col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
@@ -210,7 +210,7 @@ plotVarPart(sortCols(violin_plot))
 # Residuals after normalisation
 RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
 ```
-
+`r glue::glue_collapse(formula)`
 ### Residual calculation
 Calculate weighted residuals and add back "Dx" to the residuals
 ```{r varsToAddBack}

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Diagnosis.Rmd
@@ -35,6 +35,7 @@ library(edgeR)
 library(synapser)
 library(knitr)
 library(githubr) # get the package from devtools::install_github('brian-bot/githubr')
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
 
 synLogin()
 
@@ -118,10 +119,9 @@ random_effect <- c("Reported_Gender", "IsolationBatch")
 ```{r iterative.normalisation, results='asis'}
 writeLines(glue::glue('Using following covariates in the model:',
                  glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
-                 ' as fixed effects and ',
-                 glue::glue_collapse(random_effect, sep = ", ", last = " and "),' chosen as random effects'))
+                 ' as fixed effects.'))
 
-scaled_col_type <- dplyr::select(COVARIATES, c(adjust.covars)) %>%
+scaled_col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
   dplyr::summarise_all(class) %>% 
   tidyr::gather(variable, class)
 
@@ -134,11 +134,18 @@ scaled_adjust_covars = sapply(1:length(scaled_col_type$class), function(i){
   })
 
 # Post adjusted formula
-formula <- glue::glue("~ ", glue::glue_collapse(scaled_adjust_covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))   
+formula <- formula(glue::glue("~ ", glue::glue_collapse(scaled_adjust_covars, sep = " + ")))
+design <- model.matrix(formula, COVARIATES)
 
 # Estimate voom weights with DREAM
 geneExpr = DGEList(NEW.COUNTS)
-geneExpr = edgeR::calcNormFactors(geneExpr)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
 
 VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
                                                                formula = formula,
@@ -170,8 +177,7 @@ setMethod("plot", signature(x="EList", y="missing"),
 plot(VOOM.GENE_EXPRESSION)
 
 # Fit linear model using new weights and new design
-VOOM.GENE_EXPRESSION$E = CQN.GENE_EXPRESSION
-ADJUSTED.FIT = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION$E,
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
                                         formula = formula,
                                         data = COVARIATES,
                                         computeResiduals = TRUE)

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_DxSex.Rmd
@@ -1,0 +1,492 @@
+---
+title: "Differential Expression - HBCC - dsACC - Dx - Sex"
+author: "Kelsey Montgomery, Gabriel Hoffman, Thanneer Perumal"
+date: "`r date()`"
+output: html_document
+---
+
+```{r knit2synapse, eval=FALSE}
+library(synapser)
+library(knit2synapse)
+
+synLogin()
+
+knit2synapse::createAndKnitToFolderEntity(file = "individual-cohorts/split_by_analysis/HBCC_dsACC_DE_DxSex.Rmd",
+                                 parentId ="syn22084347",
+                                 folderName = "Differential Expression - Dx - Sex")
+```
+
+```{r libs, echo=FALSE, warning=FALSE, message=FALSE, include=FALSE}
+## Load required libraries
+library(CovariateAnalysis) # get the package from devtools::install_github('th1vairam/CovariateAnalysis@dev')
+library(data.table)
+library(tidyr)
+library(plyr)
+library(dplyr)
+library(stringr)
+library(R.utils)
+library(ggplot2)
+library(limma)
+library(psych)
+library(lme4)
+library(biomaRt)
+library(variancePartition)
+library(edgeR)
+library(synapser)
+library(knitr)
+library(githubr) # get the package from devtools::install_github('brian-bot/githubr')
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
+
+synLogin()
+
+library(foreach)
+library(future)
+library(BiocParallel)
+
+# See dream documentation to customize parallel processing       http://bioconductor.org/packages/release/bioc/vignettes/variancePartition/inst/doc/dream.html#parallel-processing
+param = SnowParam((availableCores()-2)/2, "SOCK", progressbar=TRUE)
+
+register(param)
+
+options(xtable.type="html")
+
+knitr::opts_chunk$set(
+  echo=FALSE,
+  warning=FALSE,
+  message=FALSE,
+  error = FALSE,
+  tidy = FALSE,
+  cache = TRUE)
+```
+
+```{r synapse.parameters, include=FALSE, cache=FALSE}
+parentId = 'syn22084347';
+activityName = 'Differential Expression';
+activityDescription = 'Differential Expression - Dx_Sex';
+
+thisFileName <- 'HBCC_dsACC_DE_DxSex.Rmd'
+
+# Github link
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis',thisFileName))
+```
+
+### Data download
+#### Obtain filtered and CQN normalized counts
+```{r download.data, cache=TRUE}
+downloadFile <- function(id){
+  fread(synGet(id)$path, data.table = F, header = T)
+}
+
+# Download CQN counts
+CQN_ID = "syn22086076"
+ALL_USED_IDs = c(CQN_ID)
+CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
+  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
+  data.matrix()
+  
+# Download filtered counts
+COUNTS_ID = "syn22086075"
+ALL_USED_IDs = c(ALL_USED_IDs, COUNTS_ID)
+NEW.COUNTS = downloadFile(COUNTS_ID) %>% 
+  tibble::column_to_rownames(var = "ensembl_gene_id")
+  
+# Get covariates
+COVAR_ID = "syn22086074"
+ALL_USED_IDs = c(ALL_USED_IDs, COVAR_ID)
+COVARIATES = downloadFile(COVAR_ID) %>% 
+  tibble::column_to_rownames(var = "SampleID")
+
+# Set variable class
+FactorCovariates <- c("Individual_ID", "Reported_Gender", "Dx", "IsolationBatch")
+COVARIATES[,FactorCovariates] = lapply(COVARIATES[,FactorCovariates], factor)
+
+ContCovariates <- c("ageOfDeath", "PMI", "RIN", "MappedReads", "IntragenicRate", "IntronicRate", "IntergenicRate",
+                    "GenesDetected", "ExpProfEfficiency", "rRNARate", "TotalReads","AlignmentRate", 
+                    "EV.1", "EV.2", "EV.3", "EV.4", "EV.5")
+COVARIATES[,ContCovariates] = lapply(COVARIATES[,ContCovariates], function(x){
+  x = as.numeric(as.character(gsub('[\\,\\%]','',x)))
+})
+
+# Set covariates to adjust for from model selection
+interaction <- c("Dx", "Reported_Gender")
+adjust.covars <- c("ageOfDeath", "RIN", "IntronicRate", "IntragenicRate", "IntergenicRate")
+random_effect <- c("IsolationBatch")
+```
+
+### Normalisation - Dx*Sex
+1. Dx*Sex is chosen as the primary variable of interest
+
+```{r iterative.normalisation, results='asis'}
+writeLines(glue::glue('Using following covariates in the model:',
+                      glue::glue_collapse(interaction, sep = ", "),
+                      ', ',
+                      glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
+                      ' as fixed effects.'))
+
+scaled_col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
+  dplyr::summarise_all(class) %>% 
+  tidyr::gather(variable, class)
+
+# Scale continuous variables
+scaled_adjust_covars = sapply(1:length(scaled_col_type$class), function(i){
+  switch(scaled_col_type$class[i], 
+    "factor" = paste0(scaled_col_type$variable[i]),
+    "numeric" = paste0('scale(', scaled_col_type$variable[i], ')')
+  )
+  })
+
+# Post adjusted formula
+formula <- formula(glue::glue("~ ", glue::glue_collapse(interaction, sep = "*")," + ", glue::glue_collapse(scaled_adjust_covars, sep = " + ")))   
+design <- model.matrix(formula, COVARIATES)
+ 
+# Estimate voom weights with DREAM
+geneExpr = DGEList(NEW.COUNTS)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
+
+VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
+                                                               formula = formula,
+                                                               data = COVARIATES,
+                                                               save.plot = TRUE)
+
+# How to plot a voom object if save.plot=TRUE
+# Set plot generic to voom result EList
+#' @export
+setMethod("plot", signature(x="EList", y="missing"),
+  function(x,  y, ...){
+    if( is.null(x$voom.xy) || is.null(x$voom.line)){
+        stop("x does not contain the trend information.\nvoom() must be run with save.plot=TRUE")
+    }
+    # points
+    df = data.frame(x = x$voom.xy$x,
+                    y = x$voom.xy$y)
+    # trend line
+    df.line = data.frame(x = x$voom.line$x,
+                        y = x$voom.line$y)
+    ggplot(df, aes(x,y)) + geom_point(size=.1) + theme_bw(15) + 
+      theme(aspect.ratio=1, plot.title = element_text(hjust = 0.5)) + 
+      geom_line(data=df.line, aes(x,y), color="red") + xlab(bquote(log[2](count + 0.5))) + 
+      ylab(expression( sqrt("standard deviation"))) + ggtitle("Voom: Mean-variance trend") + 
+      ylim(0, max(df$y))
+  }
+)
+  
+plot(VOOM.GENE_EXPRESSION)
+
+# Fit linear model using new weights and new design
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
+                                        formula = formula,
+                                        data = COVARIATES,
+                                        computeResiduals = TRUE)
+
+# Model categorical variables as random to report variance fractions
+col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
+  dplyr::summarise_all(class) %>% 
+  tidyr::gather(variable, class)
+
+formula_for_variance_fractions = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0('(1|', col_type$variable[i], ')'),
+    "numeric" = paste0(col_type$variable[i])
+  )
+  })
+
+# Manually specify interaction
+interaction <- c(interaction, "Dx:Reported_Gender")
+interaction_variance <- glue::glue("(1|{interaction})")
+all <- c(interaction_variance, formula_for_variance_fractions)
+formula_for_variance_fractions <- glue::glue("~ ", glue::glue_collapse(all, sep = " + "))
+violin_plot <- variancePartition::fitExtractVarPartModel(VOOM.GENE_EXPRESSION$E,
+                                                         formula = formula_for_variance_fractions,
+                                                         data = COVARIATES)
+
+plotVarPart(sortCols(violin_plot))
+
+# Residuals after normalisation
+RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
+```
+`r formula`
+### Residual calculation
+Calculate weighted residuals and add back "Dx:Sex" to the residuals
+```{r varsToAddBack}
+# Add variable of interest back to the residuals
+varsToAddIn = grep("DxOther:Reported_GenderMale", "DxSCZ:Reported_GenderMale", colnames(ADJUSTED.FIT$design), value = T)
+RESIDUAL.GENE_EXPRESSION = RESIDUAL.GENE_EXPRESSION +
+ADJUSTED.FIT$coefficients[,varsToAddIn] %*% t(ADJUSTED.FIT$design[,varsToAddIn])
+```
+
+### Coexpression of residual expression 
+```{r coexp2, cache=FALSE, fig.height=5, fig.width=5}
+cr = cor(t(RESIDUAL.GENE_EXPRESSION))
+hist(cr, main = 'Distribution of correlation between genes', xlab = 'Correlation')
+```
+
+### Clustering residual data
+```{r decompse.normalise.data2, fig.height=8, fig.width=8, results='asis'}
+# Find principal components of expression to plot
+PC <- prcomp(RESIDUAL.GENE_EXPRESSION, scale.=T, center = T)
+
+# Plot first 4 PCs
+plotdata <- data.frame(SampleID=rownames(PC$rotation), 
+                       PC1=PC$rotation[,1], 
+                       PC2=PC$rotation[,2])
+
+plotdata <- left_join(plotdata, rownameToFirstColumn(COVARIATES, 'SampleID')) %>% 
+  dplyr::mutate(Tissue = "dsACC")
+
+p <- ggplot(plotdata, aes(x=PC1, y=PC2))
+p <- p + geom_point(aes(shape=Tissue, size=ageOfDeath))
+p <- p + theme_bw() + theme(legend.position="right") + facet_grid(Tissue~., scales = 'free_y')
+p
+```
+
+```{r decompose.normalise.data2.1, fig.height=8, fig.width=12, results='asis'}
+# Eucledian tree based analysis
+COVARIATES.tmp = data.matrix(COVARIATES[,c('Dx', 'Reported_Gender'), drop = FALSE])
+
+tree = hclust(as.dist(t(RESIDUAL.GENE_EXPRESSION)))
+cols = WGCNA::labels2colors(COVARIATES.tmp);
+
+WGCNA::plotDendroAndColors(tree, 
+                           colors = cols, 
+                           dendroLabels = FALSE, 
+                           abHeight = 0.80, 
+                           main = "Sample dendrogram",
+                           groupLabels = colnames(COVARIATES.tmp[,c('Dx','Reported_Gender'), drop = FALSE]))
+```
+
+```{r temp1, include=F}
+dev.off()
+gc()
+```
+
+### Differential expression analysis (SCZ - Control - Other)
+Genes that are differentially expressed at an FDR <= 0.05 are:
+```{r set-formula}
+formula <- glue::glue("~ 0 + Dx_Sex + ", glue::glue_collapse(adjust.covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))
+```
+
+`r formula`
+
+Dx_Sex is 6 levels, SCZ_Female, SCZ_Male, Other_Female, Other_Male, Control_Female, Control_Male
+
+```{r diffExp, fig.height=10, fig.width=15}
+# Test Dx-Sex
+COVARIATES <- COVARIATES %>%
+  tibble::rownames_to_column(var = "samples") %>% 
+  tidyr::unite("Dx_Sex",
+               dplyr::all_of(c("Dx", "Reported_Gender")),
+               remove = TRUE) %>% 
+  dplyr::mutate(`Dx_Sex` = as.factor(`Dx_Sex`)) %>% 
+  tibble::column_to_rownames(var = "samples")
+L1 = variancePartition::getContrast(exprObj = VOOM.GENE_EXPRESSION, 
+                                   formula = formula, 
+                                   data = COVARIATES, 
+                                   coefficient = c("Dx_SexControl_Male", "Dx_SexControl_Female"))
+L2 = c(1, -1, 0, 0, -1, 1, 0, 0, 0, 0, 0)
+L3 = c(1, -1, -1, 1, 0, 0, 0, 0, 0, 0, 0)
+# Manually set comparison between SCZ+Other vs. Control 
+L = cbind(L1, L2, L3)
+
+contrast <- c(glue::glue_collapse(names(L1[L1 != 0]), "-"), 
+              glue::glue("Dx_SexSCZ_MaleDx_SexControl_Male-Dx_SexSCZ_FemaleDx_SexControl_Female"),
+              glue::glue("Dx_SexOther_MaleDx_SexControl_Male-Dx_SexOther_FemaleDx_SexControl_Female")
+)
+# Visualize contrast matrix
+plotContrasts(L) 
+
+# Fit contrast
+FIT.CONTR = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION$E,
+                                     formula = formula,
+                                     data = COVARIATES,
+                                     L = L,
+                                     suppressWarnings = TRUE)
+
+# Get background genes 
+backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
+  dplyr::mutate(id = gene_id) %>%
+  tidyr::separate(id, c('ensembl_gene_id','position'), sep = '\\.')
+
+# Get gene lengths
+counts = 'syn21867866'
+ALL_USED_IDs = c(counts, ALL_USED_IDs)
+counts = downloadFile(counts) %>% data.frame()
+gene_lengths = counts[,c("Geneid", "Length")] %>% 
+  dplyr::rename(gene_id = Geneid)
+rm(counts)
+
+# Define biomart object
+mart <- biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL",
+                host = "uswest.ensembl.org", # Ensembl Release 99 (January 2020)
+                dataset = "hsapiens_gene_ensembl")
+
+# Query biomart
+Ensemble2HGNC <- getBM(attributes = c("ensembl_gene_id", "hgnc_symbol", 
+                                      "percentage_gene_gc_content", "gene_biotype", 
+                                      "chromosome_name"),
+                       filters = "ensembl_gene_id", 
+                       values = backgroundGenes$ensembl_gene_id,
+                       mart = mart)
+
+# Get differential expression
+DE = lapply(glue::glue("L{1:3}"), function(i, FIT){
+  topTable(FIT, coef=i, number = Inf) %>%
+    rownameToFirstColumn('gene_id') %>% 
+    left_join(backgroundGenes)
+}, FIT.CONTR) 
+names(DE) <- contrast
+
+DE = DE %>% 
+  rbindlist(idcol = 'Comparison') %>%
+  dplyr::mutate(Comparison = gsub('Dx_Sex','',Comparison),
+                Direction = logFC/abs(logFC),
+                Direction = factor(Direction, c(-1,1), c('-1' = 'DOWN', '1' = 'UP')),
+                Direction = as.character(Direction)) %>%
+  tidyr::separate(Comparison, into = c('ref.state','to.state'), sep = '-') %>%
+  tidyr::unite(Comparison, `ref.state`, `to.state`, sep = '_vs_') %>%
+  left_join(Ensemble2HGNC) %>%
+  left_join(gene_lengths)
+DE$Direction[DE$adj.P.Val > 0.05 | abs(DE$logFC) < log2(1.2)] = 'NONE'
+
+tmp = DE %>%
+  dplyr::filter(adj.P.Val <= 0.05) %>%
+  dplyr::select(ensembl_gene_id, Comparison) %>%
+  group_by(Comparison) %>%
+  dplyr::summarise(FDR_0_05 = length(unique(ensembl_gene_id)))
+
+tmp1 = DE %>%
+  dplyr::filter(adj.P.Val <= 0.05, abs(logFC) >= log2(1.2)) %>%
+  dplyr::select(ensembl_gene_id, Comparison) %>%
+  group_by(Comparison) %>%
+  dplyr::summarise(FDR_0_05_FC_1.2 = length(unique(ensembl_gene_id)))
+
+kable(full_join(tmp,tmp1))
+
+p = ggplot(DE, aes(y = -log10(adj.P.Val), x = logFC, color = Direction)) + geom_point() + xlim(c(-1,1))
+p = p + scale_color_manual(values = c('green','grey','red')) + theme_bw() %+replace% theme(legend.position = 'top')
+p = p + facet_grid(.~Comparison, scales = 'fixed')
+p
+```
+
+### Associate differential expression results with gc content, gene length and average expression
+```{r associate.de, fig.height=10, fig.width=15}
+pl = list()
+pl[[1]] = ggplot(DE %>% 
+                   arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = log10(Length), y = logFC, color = Direction)) + geom_point() 
+pl[[1]] = pl[[1]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = log10(Length), y = logFC))
+pl[[1]] = pl[[1]] + scale_color_manual(values = c('green','grey','red'))
+pl[[1]] = pl[[1]] + theme(legend.position = 'top')
+
+pl[[2]] = ggplot(DE %>% 
+                   arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = percentage_gene_gc_content, y = logFC, color = Direction)) + geom_point()
+pl[[2]] = pl[[2]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = percentage_gene_gc_content, y = logFC))
+pl[[2]] = pl[[2]] + scale_color_manual(values = c('green','grey','red'))
+pl[[2]] = pl[[2]] + theme(legend.position = 'top')
+
+pl[[3]] = ggplot(DE %>% 
+                    arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = AveExpr, y = logFC, color = Direction)) + geom_point()
+pl[[3]] = pl[[3]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = AveExpr, y = logFC))
+pl[[3]] = pl[[3]] + scale_color_manual(values = c('green','grey','red'))
+pl[[3]] = pl[[3]] + theme(legend.position = 'top')
+
+multiplot(plotlist = pl, cols = 3)
+```
+### Source Code
+`r thisFile`
+
+### Store files in synapse
+```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}
+# Set annotations
+all.annotations = list(
+  dataType = 'geneExpression',
+  dataSubtype = 'processed',
+  assay	 = 'rnaSeq',
+  
+  tissue	= 'dorsolateral prefrontal cortex', 
+  study = 'CMC', 
+
+  species = 'Human',
+  consortium	= 'CMC',
+   
+  analysisType	= "data normalization",
+  
+  transcriptNormalizationMethod	= 'CQN',
+  transcriptQuantificationMethod = 'featureCounts',
+  referenceSet = 'GRCh38'
+)
+
+# Code
+CODE <- Folder(name = "Differential Expression - Dx - Sex", parentId = parentId)
+CODE <- synStore(CODE)
+
+# Store residual gene expression for network analysis
+RESIDUAL.GENE_EXPRESSION %>%
+  rownameToFirstColumn('ensembl_gene_id') %>%
+  write.table(file = 'CMC_dsACC_Dx_Sex_netResidualExpression.tsv', sep = '\t', row.names=F, quote=F)
+nEXP_OBJ = File('CMC_dsACC_Dx_Sex_netResidualExpression.tsv', 
+                name = 'Dx_Sex Normalised, covariates removed residual expression (for network analysis)', 
+                parentId = CODE$properties$id)
+nEXP_OBJ = synStore(nEXP_OBJ, used = ALL_USED_IDs, activityName = activityName, 
+                    executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(nEXP_OBJ, annotations = all.annotations)
+
+# Store differential expression results
+write.table(DE, file = 'CMC_dsACC_Dx_Sex_DiffExpression.tsv', sep = '\t', row.names=F, quote=F)
+DEXP_OBJ = File('CMC_dsACC_Dx_Sex_DiffExpression.tsv', 
+                name = 'Differential Expression Results (Dx_Sex)', 
+                parentId = CODE$properties$id)
+DEXP_OBJ = synStore(DEXP_OBJ, used = ALL_USED_IDs, activityName = activityName, 
+                    executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(DEXP_OBJ, annotations = all.annotations)
+
+# Store adjusted fit linear mixed model object as RDS - Dx_Sex
+saveRDS(ADJUSTED.FIT, file = 'CMC_dsACC_Dx_Sex_dream-output.rds')
+ADJ_OBJ = File('CMC_dsACC_Dx_Sex_dream-output.rds',
+               name = 'Dream Output object - Dx_Sex', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store variancePartition
+saveRDS(sortCols(violin_plot), file = 'CMC_dsACC_Dx_Sex_variancePartition.rds')
+ADJ_OBJ = File('CMC_dsACC_Dx_Sex_variancePartition.rds',
+               name = 'Variance Partition result', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store voom object
+saveRDS(VOOM.GENE_EXPRESSION, file = 'CMC_dsACC_Dx_Sex_voom.rds')
+ADJ_OBJ = File('CMC_dsACC_Dx_Sex_voom.rds',
+               name = 'voom object', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store contrasts
+saveRDS(L, file = 'CMC_dsACC_Dx_Sex_contrasts.rds')
+ADJ_OBJ = File('CMC_dsACC_Dx_Sex_contrasts.rds',
+               name = 'contrast matrix', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store formula
+saveRDS(formula, file = 'CMC_dsACC_Dx_Sex_formula.rds')
+ADJ_OBJ = File('CMC_dsACC_Dx_Sex_formula.rds',
+               name = 'formula', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+```

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_DxSex.Rmd
@@ -82,8 +82,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22086076"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22086075"
@@ -96,6 +95,12 @@ COVAR_ID = "syn22086074"
 ALL_USED_IDs = c(ALL_USED_IDs, COVAR_ID)
 COVARIATES = downloadFile(COVAR_ID) %>% 
   tibble::column_to_rownames(var = "SampleID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Reported_Gender", "Dx", "IsolationBatch")

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_DxSex.Rmd
@@ -68,7 +68,7 @@ thisFileName <- 'HBCC_dsACC_DE_DxSex.Rmd'
 
 # Github link
 thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
-thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis',thisFileName))
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
 ### Data download
@@ -216,7 +216,7 @@ plotVarPart(sortCols(violin_plot))
 # Residuals after normalisation
 RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
 ```
-`r formula`
+`r glue::glue_collapse(formula)`
 ### Residual calculation
 Calculate weighted residuals and add back "Dx:Sex" to the residuals
 ```{r varsToAddBack}

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_DxSex.Rmd
@@ -403,7 +403,7 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 multiplot(plotlist = pl, cols = 3)
 ```
 ### Source Code
-`r thisFile`
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Sex.Rmd
@@ -82,8 +82,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22086076"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22086075"
@@ -96,6 +95,12 @@ COVAR_ID = "syn22086074"
 ALL_USED_IDs = c(ALL_USED_IDs, COVAR_ID)
 COVARIATES = downloadFile(COVAR_ID) %>% 
   tibble::column_to_rownames(var = "SampleID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Reported_Gender", "Dx", "IsolationBatch")

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Sex.Rmd
@@ -212,7 +212,7 @@ plotVarPart(sortCols(violin_plot))
 # Residuals after normalisation
 RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
 ```
-
+`r glue::glue_collapse(formula)`
 ### Residual calculation
 Calculate weighted residuals and add back "Sex" to the residuals
 ```{r varsToAddBack}

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Sex.Rmd
@@ -35,6 +35,7 @@ library(edgeR)
 library(synapser)
 library(knitr)
 library(githubr) # get the package from devtools::install_github('brian-bot/githubr')
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
 
 synLogin()
 
@@ -115,32 +116,38 @@ random_effect <- c("IsolationBatch")
 ```
 
 ### Normalisation - Sex
-1. Sex is chosen as the primary variable of interest (i.e., covariate adjustments is conditioned on diagnosis)
+1. Sex is chosen as the primary variable of interest
 
 ```{r iterative.normalisation, results='asis'}
 writeLines(glue::glue('Using following covariates in the model:',
-                 glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
-                 ' as fixed effects and ',
-                 glue::glue_collapse(random_effect, sep = ", ", last = " and "),' chosen as random effects'))
+                 glue::glue_collapse(c(adjust.covars,random_effect), sep = ", ", last = " and "),
+                 ' as fixed effects.'))
 
-scaled_col_type <- dplyr::select(COVARIATES, c(adjust.covars)) %>%
+col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
   dplyr::summarise_all(class) %>% 
   tidyr::gather(variable, class)
 
 # Scale continuous variables
-scaled_adjust_covars = sapply(1:length(scaled_col_type$class), function(i){
-  switch(scaled_col_type$class[i], 
-    "factor" = paste0(scaled_col_type$variable[i]),
-    "numeric" = paste0('scale(', scaled_col_type$variable[i], ')')
+covars = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0(col_type$variable[i]),
+    "numeric" = paste0('scale(', col_type$variable[i], ')')
   )
   })
 
 # Post adjusted formula
-formula <- glue::glue("~ ", glue::glue_collapse(scaled_adjust_covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))   
+formula <- formula(glue::glue("~", glue::glue_collapse(covars, sep = " + ")))
+design <- model.matrix(formula, COVARIATES)
 
 # Estimate voom weights with DREAM
 geneExpr = DGEList(NEW.COUNTS)
-geneExpr = edgeR::calcNormFactors(geneExpr)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
 
 VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
                                                                formula = formula,
@@ -172,8 +179,7 @@ setMethod("plot", signature(x="EList", y="missing"),
 plot(VOOM.GENE_EXPRESSION)
 
 # Fit linear model using new weights and new design
-VOOM.GENE_EXPRESSION$E = CQN.GENE_EXPRESSION
-ADJUSTED.FIT = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION$E,
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
                                         formula = formula,
                                         data = COVARIATES,
                                         computeResiduals = TRUE)

--- a/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/HBCC_dsACC_DE_Sex.Rmd
@@ -62,13 +62,13 @@ knitr::opts_chunk$set(
 ```{r synapse.parameters, include=FALSE, cache=FALSE}
 parentId = 'syn22084347';
 activityName = 'Differential Expression';
-activityDescription = 'Differential Expression - ';
+activityDescription = 'Differential Expression - Sex';
 
-thisFileName <- 'HBCC_dsACC_DE.Rmd'
+thisFileName <- 'HBCC_dsACC_DE_Sex.Rmd'
 
 # Github link
-thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='master')
-thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/',thisFileName))
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
 ### Data download
@@ -300,7 +300,7 @@ backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
 
 # Get gene lengths
 counts = 'syn21867866'
-ALL_USED_IDs = counts
+ALL_USED_IDs = c(ALL_USED_IDs, counts)
 counts = downloadFile(counts) %>% data.frame()
 gene_lengths = counts[,c("Geneid", "Length")] %>% 
   dplyr::rename(gene_id = Geneid)
@@ -382,6 +382,8 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 
 multiplot(plotlist = pl, cols = 3)
 ```
+### Source Code
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Diagnosis.Rmd
@@ -64,11 +64,11 @@ parentId = 'syn22012953';
 activityName = 'Differential Expression';
 activityDescription = 'Differential Expression - Dx';
 
-thisFileName <- 'MSSM-Penn-Pitt_ACC_DE.Rmd'
+thisFileName <- 'MSSM-Penn-Pitt_ACC_DE_Diagnosis.Rmd'
 
 # Github link
-thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='master')
-thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/',thisFileName))
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
 ### Data download
@@ -324,7 +324,7 @@ backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
 
 # Get gene lengths
 counts = 'syn21867938'
-ALL_USED_IDs = counts
+ALL_USED_IDs = c(ALL_USED_IDs, counts)
 counts = downloadFile(counts) %>% data.frame()
 gene_lengths = counts[,c("Geneid", "Length")] %>% 
   dplyr::rename(gene_id = Geneid)
@@ -406,6 +406,8 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 
 multiplot(plotlist = pl, cols = 3)
 ```
+### Source Code
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Diagnosis.Rmd
@@ -35,6 +35,7 @@ library(edgeR)
 library(synapser)
 library(knitr)
 library(githubr) # get the package from devtools::install_github('brian-bot/githubr')
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
 
 synLogin()
 
@@ -126,15 +127,33 @@ random_effect <- c("Institution", "Reported_Gender")
 ```{r iterative.normalisation, results='asis'}
 writeLines(glue::glue('Using following covariates in the model:',
                  glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
-                 ' as fixed effects and',
-                 glue::glue_collapse(random_effect, sep = ", ", last = " and "),' chosen as random effects'))
+                 ' as fixed effects.'))
+
+col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
+  dplyr::summarise_all(class) %>% 
+  tidyr::gather(variable, class)
+
+# Scale continuous variables
+covars = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0(col_type$variable[i]),
+    "numeric" = paste0('scale(', col_type$variable[i], ')')
+  )
+  })
 
 # Post adjusted formula
-formula <- glue::glue("~ ", glue::glue_collapse(adjust.covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))    
+formula <- formula(glue::glue("~", glue::glue_collapse(covars, sep = " + ")))
+design <- model.matrix(formula, COVARIATES)
 
 # Estimate voom weights with DREAM
 geneExpr = DGEList(NEW.COUNTS)
-geneExpr = edgeR::calcNormFactors(geneExpr)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
 
 VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
                                                                formula = formula,
@@ -166,8 +185,7 @@ setMethod("plot", signature(x="EList", y="missing"),
 plot(VOOM.GENE_EXPRESSION)
 
 # Fit linear model using new weights and new design
-VOOM.GENE_EXPRESSION$E = CQN.GENE_EXPRESSION
-ADJUSTED.FIT = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION,
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
                                         formula = formula,
                                         data = COVARIATES,
                                         computeResiduals = TRUE)

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Diagnosis.Rmd
@@ -82,8 +82,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22013154"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22013153"
@@ -104,6 +103,12 @@ METADATA = downloadFile(MD_ID) %>%
 
 COVARIATES = right_join(METADATA, COVARIATES, by = c("Sample_RNA_ID" = "SampleID")) %>% 
   tibble::column_to_rownames(var = "Sample_RNA_ID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Institution", "Reported_Gender", "LibraryBatch", "Dx", "RibozeroBatch", "FlowcellBatch")

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Diagnosis.Rmd
@@ -11,7 +11,7 @@ library(knit2synapse)
 
 synLogin()
 
-knit2synapse::createAndKnitToFolderEntity(file = "individual-cohorts/MSSM-Penn-Pitt_ACC_DE.Rmd",
+knit2synapse::createAndKnitToFolderEntity(file = "individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Diagnosis.Rmd",
                                  parentId ="syn22012953",
                                  folderName = "Differential Expression - Dx")
 ```

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd
@@ -78,8 +78,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22013154"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22013153"
@@ -100,6 +99,12 @@ METADATA = downloadFile(MD_ID) %>%
 
 COVARIATES = right_join(METADATA, COVARIATES, by = c("Sample_RNA_ID" = "SampleID")) %>% 
   tibble::column_to_rownames(var = "Sample_RNA_ID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Institution", "Reported_Gender", "LibraryBatch", "Dx", "RibozeroBatch", "FlowcellBatch")

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd
@@ -64,7 +64,7 @@ thisFileName <- 'MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd'
 
 # Github link
 thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
-thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis',thisFileName))
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
 ### Data download
@@ -219,7 +219,7 @@ plotVarPart(sortCols(violin_plot))
 # Residuals after normalisation
 RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
 ```
-`r formula`
+`r glue::glue_collapse(formula)`
 ### Residual calculation
 Calculate weighted residuals and add back "Dx:Sex" to the residuals
 ```{r varsToAddBack}

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd
@@ -410,7 +410,7 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 multiplot(plotlist = pl, cols = 3)
 ```
 ### Source Code
-`r thisFile`
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd
@@ -1,0 +1,499 @@
+---
+title: "Differential Expression - MSSM-Penn-Pitt - ACC - Dx - Sex"
+author: "Kelsey Montgomery, Gabriel Hoffman, Thanneer Perumal"
+date: "`r date()`"
+output: html_document
+---
+
+```{r knit2synapse, eval=FALSE}
+library(synapser)
+library(knit2synapse)
+
+synLogin()
+
+knit2synapse::createAndKnitToFolderEntity(file = "individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd",
+                                 parentId ="syn22012953",
+                                 folderName = "Differential Expression - Dx - Sex")
+```
+
+```{r libs, echo=FALSE, warning=FALSE, message=FALSE, include=FALSE}
+## Load required libraries
+library(data.table)
+library(dplyr)
+library(R.utils)
+library(psych)
+library(lme4)
+library(variancePartition)
+library(synapser)
+library(knitr)
+library(githubr)
+library(CovariateAnalysis)
+library(edgeR)
+library(WGCNA)
+library(biomaRt)
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
+
+synLogin()
+
+library(foreach)
+library(future)
+library(BiocParallel)
+
+# See dream documentation to customize parallel processing       http://bioconductor.org/packages/release/bioc/vignettes/variancePartition/inst/doc/dream.html#parallel-processing
+param = SnowParam((availableCores()-2)/2, "SOCK", progressbar=TRUE)
+
+register(param)
+
+options(xtable.type="html")
+
+knitr::opts_chunk$set(
+  echo=FALSE,
+  warning=FALSE,
+  message=FALSE,
+  error = FALSE,
+  tidy = FALSE,
+  cache = TRUE)
+```
+
+```{r synapse.parameters, include=FALSE, cache=FALSE}
+parentId = 'syn22012953';
+activityName = 'Differential Expression';
+activityDescription = 'Differential Expression - Dx - Sex';
+
+thisFileName <- 'MSSM-Penn-Pitt_ACC_DE_DxSex.Rmd'
+
+# Github link
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis',thisFileName))
+```
+
+### Data download
+#### Obtain filtered and CQN normalized counts
+```{r download.data, cache=TRUE}
+downloadFile <- function(id){
+  fread(synGet(id)$path, data.table = F)
+}
+
+# Download CQN counts
+CQN_ID = "syn22013154"
+ALL_USED_IDs = c(CQN_ID)
+CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
+  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
+  data.matrix()
+  
+# Download filtered counts
+COUNTS_ID = "syn22013153"
+ALL_USED_IDs = c(ALL_USED_IDs, COUNTS_ID)
+NEW.COUNTS = downloadFile(COUNTS_ID) %>% 
+  tibble::column_to_rownames(var = "ensembl_gene_id")
+  
+# Get covariates
+COVAR_ID = "syn22013150"
+ALL_USED_IDs = c(ALL_USED_IDs, COVAR_ID)
+COVARIATES = downloadFile(COVAR_ID) 
+
+# dropped individual id 
+MD_ID = "syn16816488"
+ALL_USED_IDs = c(ALL_USED_IDs, COUNTS_ID)
+METADATA = downloadFile(MD_ID) %>% 
+  dplyr::select(Individual_ID, Sample_RNA_ID)
+
+COVARIATES = right_join(METADATA, COVARIATES, by = c("Sample_RNA_ID" = "SampleID")) %>% 
+  tibble::column_to_rownames(var = "Sample_RNA_ID")
+
+# Set variable class
+FactorCovariates <- c("Individual_ID", "Institution", "Reported_Gender", "LibraryBatch", "Dx", "RibozeroBatch", "FlowcellBatch")
+COVARIATES[,FactorCovariates] = lapply(COVARIATES[,FactorCovariates], factor)
+
+ContCovariates <- c("ageOfDeath", "PMI", "RIN", "MappedReads", "IntragenicRate", "IntronicRate", "IntergenicRate",
+                    "GenesDetected", "ExpProfEfficiency", "rRNARate", "TotalReads","AlignmentRate", 
+                    "EV.1", "EV.2", "EV.3", "EV.4", "EV.5")
+COVARIATES[,ContCovariates] = lapply(COVARIATES[,ContCovariates], function(x){
+  x = as.numeric(as.character(gsub('[\\,\\%]','',x)))
+})
+
+# Set covariates to adjust for from model selection
+interaction <- c("Dx", "Reported_Gender")
+adjust.covars <- c("ageOfDeath", "RIN2", "RIN", "rRNARate", "IntronicRate", "IntragenicRate", "IntergenicRate")
+random_effect <- c("Institution")
+```
+
+### Normalisation - Dx*Sex
+1. Dx*Sex is chosen as the primary variable of interest
+
+```{r iterative.normalisation, results='asis'}
+writeLines(glue::glue('Using following covariates in the model:',
+                      glue::glue_collapse(interaction, sep = ", "),
+                      ', ',
+                      glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
+                      ' as fixed effects and',
+                      glue::glue_collapse(random_effect, sep = ", ", last = " and "),' chosen as random effects'))
+
+col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
+  dplyr::summarise_all(class) %>% 
+  tidyr::gather(variable, class)
+
+# Scale continuous variables
+covars = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0(col_type$variable[i]),
+    "numeric" = paste0('scale(', col_type$variable[i], ')')
+  )
+  })
+
+# Post adjusted formula
+formula <- formula(glue::glue("~ ", glue::glue_collapse(interaction, sep = "*")," + ", glue::glue_collapse(covars, sep = " + ")))
+design <- model.matrix(formula, COVARIATES)
+ 
+# Estimate voom weights with DREAM
+geneExpr = DGEList(NEW.COUNTS)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
+
+VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
+                                                               formula = formula,
+                                                               data = COVARIATES,
+                                                               save.plot = TRUE)
+
+# How to plot a voom object if save.plot=TRUE
+# Set plot generic to voom result EList
+#' @export
+setMethod("plot", signature(x="EList", y="missing"),
+  function(x,  y, ...){
+    if( is.null(x$voom.xy) || is.null(x$voom.line)){
+        stop("x does not contain the trend information.\nvoom() must be run with save.plot=TRUE")
+    }
+    # points
+    df = data.frame(x = x$voom.xy$x,
+                    y = x$voom.xy$y)
+    # trend line
+    df.line = data.frame(x = x$voom.line$x,
+                        y = x$voom.line$y)
+    ggplot(df, aes(x,y)) + geom_point(size=.1) + theme_bw(15) + 
+      theme(aspect.ratio=1, plot.title = element_text(hjust = 0.5)) + 
+      geom_line(data=df.line, aes(x,y), color="red") + xlab(bquote(log[2](count + 0.5))) + 
+      ylab(expression( sqrt("standard deviation"))) + ggtitle("Voom: Mean-variance trend") + 
+      ylim(0, max(df$y))
+  }
+)
+  
+plot(VOOM.GENE_EXPRESSION)
+
+# Fit linear model using new weights and new design
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
+                                        formula = formula,
+                                        data = COVARIATES,
+                                        computeResiduals = TRUE)
+
+# Model categorical variables as random to report variance fractions
+formula_for_variance_fractions = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0('(1|', col_type$variable[i], ')'),
+    "numeric" = paste0('scale(', col_type$variable[i], ')')
+  )
+  })
+
+# Manually specify interaction
+interaction <- c(interaction, "Dx:Reported_Gender")
+interaction_variance <- glue::glue("(1|{interaction})")
+all <- c(interaction_variance, formula_for_variance_fractions)
+
+formula_for_variance_fractions <- glue::glue("~ ", glue::glue_collapse(all, sep = " + "))
+
+violin_plot <- variancePartition::fitExtractVarPartModel(VOOM.GENE_EXPRESSION,
+                                                         formula = formula_for_variance_fractions,
+                                                         data = COVARIATES)
+
+plotVarPart(sortCols(violin_plot))
+
+# Residuals after normalisation
+RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
+```
+`r formula`
+### Residual calculation
+Calculate weighted residuals and add back "Dx:Sex" to the residuals
+```{r varsToAddBack}
+# Add variable of interest back to the residuals
+varsToAddIn = grep("DxOther:Reported_GenderMale", "DxSCZ:Reported_GenderMale", colnames(ADJUSTED.FIT$design), value = T)
+RESIDUAL.GENE_EXPRESSION = RESIDUAL.GENE_EXPRESSION +
+  ADJUSTED.FIT$coefficients[,varsToAddIn] %*% t(ADJUSTED.FIT$design[,varsToAddIn])
+```
+
+### Coexpression of residual expression 
+```{r coexp2, cache=FALSE, fig.height=5, fig.width=5}
+cr = cor(t(RESIDUAL.GENE_EXPRESSION))
+hist(cr, main = 'Distribution of correlation between genes', xlab = 'Correlation')
+```
+
+### Clustering residual data
+```{r decompse.normalise.data2, fig.height=8, fig.width=8, results='asis'}
+# Find principal components of expression to plot
+PC <- prcomp(RESIDUAL.GENE_EXPRESSION, scale.=T, center = T)
+
+# Plot first 4 PCs
+plotdata <- data.frame(SampleID=rownames(PC$rotation), 
+                       PC1=PC$rotation[,1], 
+                       PC2=PC$rotation[,2])
+
+plotdata <- left_join(plotdata, rownameToFirstColumn(COVARIATES, 'SampleID')) %>% 
+  dplyr::mutate(Tissue = "ACC")
+
+p <- ggplot(plotdata, aes(x=PC1, y=PC2))
+p <- p + geom_point(aes(color=Institution, shape=Tissue, size=ageOfDeath))
+p <- p + theme_bw() + theme(legend.position="right") + facet_grid(Tissue~., scales = 'free_y')
+p
+```
+
+```{r decompose.normalise.data2.1, fig.height=8, fig.width=12, results='asis'}
+# Eucledian tree based analysis
+COVARIATES.tmp = data.matrix(COVARIATES[,c('Dx', 'Reported_Gender', 'Institution'), drop = FALSE])
+
+tree = hclust(as.dist(t(RESIDUAL.GENE_EXPRESSION)))
+cols = WGCNA::labels2colors(COVARIATES.tmp);
+
+WGCNA::plotDendroAndColors(tree, 
+                           colors = cols, 
+                           dendroLabels = FALSE, 
+                           abHeight = 0.80, 
+                           main = "Sample dendrogram",
+                           groupLabels = colnames(COVARIATES.tmp[,c('Dx','Reported_Gender', 'Institution'), drop = FALSE]))
+```
+
+```{r temp1, include=F}
+dev.off()
+gc()
+```
+
+### Differential expression analysis (SCZ - Control - Other)
+Genes that are differentially expressed at an FDR <= 0.05 are:
+```{r set-formula}
+adjust.covars <- adjust.covars[!(adjust.covars %in% "RIN2")]
+formula <- glue::glue("~ 0 + Dx_Sex + ", glue::glue_collapse(adjust.covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))    
+```
+
+`r formula`
+
+Dx_Sex is 6 levels, SCZ_Female, SCZ_Male, Other_Female, Other_Male, Control_Female, Control_Male
+
+```{r diffExp, fig.height=10, fig.width=15}
+# Test Dx-Sex
+COVARIATES <- COVARIATES %>%
+  tibble::rownames_to_column(var = "samples") %>% 
+  tidyr::unite("Dx_Sex",
+               dplyr::all_of(c("Dx", "Reported_Gender")),
+               remove = TRUE) %>% 
+  dplyr::mutate(`Dx_Sex` = as.factor(`Dx_Sex`)) %>% 
+  tibble::column_to_rownames(var = "samples")
+
+L1 = variancePartition::getContrast(exprObj = VOOM.GENE_EXPRESSION, 
+                                   formula = formula, 
+                                   data = COVARIATES, 
+                                   coefficient = c("Dx_SexControl_Male", "Dx_SexControl_Female"))
+L2 = c(1, -1, 0, 0, -1, 1, 0, 0, 0, 0, 0, 0)
+L3 = c(1, -1, -1, 1, 0, 0, 0, 0, 0, 0, 0, 0)
+
+# Manually set comparison between SCZ+Other vs. Control 
+L = cbind(L1, L2, L3)
+
+contrast <- c(glue::glue_collapse(names(L1[L1 != 0]), "-"), 
+              glue::glue("Dx_SexSCZ_MaleDx_SexControl_Male-Dx_SexSCZ_FemaleDx_SexControl_Female"),
+              glue::glue("Dx_SexOther_MaleDx_SexControl_Male-Dx_SexOther_FemaleDx_SexControl_Female")
+)
+
+# Visualize contrast matrix
+plotContrasts(L) 
+
+# Fit contrast
+FIT.CONTR = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION,
+                                     formula = formula,
+                                     data = COVARIATES,
+                                     L = L,
+                                     suppressWarnings = TRUE)
+
+# Get background genes 
+backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
+  dplyr::mutate(id = gene_id) %>%
+  tidyr::separate(id, c('ensembl_gene_id','position'), sep = '\\.')
+
+# Get gene lengths
+counts = 'syn21867938'
+ALL_USED_IDs = c(counts, ALL_USED_IDs)
+counts = downloadFile(counts) %>% data.frame()
+gene_lengths = counts[,c("Geneid", "Length")] %>% 
+  dplyr::rename(gene_id = Geneid)
+rm(counts)
+
+# Define biomart object
+mart <- biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL",
+                host = "uswest.ensembl.org", # Ensembl Release 99 (January 2020)
+                dataset = "hsapiens_gene_ensembl")
+
+# Query biomart
+Ensemble2HGNC <- getBM(attributes = c("ensembl_gene_id", "hgnc_symbol", 
+                                      "percentage_gene_gc_content", "gene_biotype", 
+                                      "chromosome_name"),
+                       filters = "ensembl_gene_id", 
+                       values = backgroundGenes$ensembl_gene_id,
+                       mart = mart)
+
+# Get differential expression
+DE = lapply(glue::glue("L{1:3}"), function(i, FIT){
+  topTable(FIT, coef=i, number = Inf) %>%
+    rownameToFirstColumn('gene_id') %>% 
+    left_join(backgroundGenes)
+}, FIT.CONTR) 
+names(DE) <- contrast
+
+DE = DE %>% 
+  rbindlist(idcol = 'Comparison') %>%
+  dplyr::mutate(Comparison = gsub('Dx_Sex','',Comparison),
+                Direction = logFC/abs(logFC),
+                Direction = factor(Direction, c(-1,1), c('-1' = 'DOWN', '1' = 'UP')),
+                Direction = as.character(Direction)) %>%
+  tidyr::separate(Comparison, into = c('ref.state','to.state'), sep = '-') %>%
+  tidyr::unite(Comparison, `ref.state`, `to.state`, sep = '_vs_') %>%
+  left_join(Ensemble2HGNC) %>%
+  left_join(gene_lengths)
+DE$Direction[DE$adj.P.Val > 0.05 | abs(DE$logFC) < log2(1.2)] = 'NONE'
+
+tmp = DE %>%
+  dplyr::filter(adj.P.Val <= 0.05) %>%
+  dplyr::select(ensembl_gene_id, Comparison) %>%
+  group_by(Comparison) %>%
+  dplyr::summarise(FDR_0_05 = length(unique(ensembl_gene_id)))
+
+tmp1 = DE %>%
+  dplyr::filter(adj.P.Val <= 0.05, abs(logFC) >= log2(1.2)) %>%
+  dplyr::select(ensembl_gene_id, Comparison) %>%
+  group_by(Comparison) %>%
+  dplyr::summarise(FDR_0_05_FC_1.2 = length(unique(ensembl_gene_id)))
+
+kable(full_join(tmp,tmp1))
+
+p = ggplot(DE, aes(y = -log10(adj.P.Val), x = logFC, color = Direction)) + geom_point() + xlim(c(-1,1)) + ylim(c(0,100))
+p = p + scale_color_manual(values = c('green','grey','red')) + theme_bw() %+replace% theme(legend.position = 'top')
+p = p + facet_grid(.~Comparison, scales = 'fixed')
+p
+```
+
+### Associate differential expression results with gc content, gene length and average expression
+```{r associate.de, fig.height=10, fig.width=15}
+pl = list()
+pl[[1]] = ggplot(DE %>% 
+                   arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = log10(Length), y = logFC, color = Direction)) + geom_point() 
+pl[[1]] = pl[[1]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = log10(Length), y = logFC))
+pl[[1]] = pl[[1]] + scale_color_manual(values = c('green','grey','red'))
+pl[[1]] = pl[[1]] + theme(legend.position = 'top')
+
+pl[[2]] = ggplot(DE %>% 
+                   arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = percentage_gene_gc_content, y = logFC, color = Direction)) + geom_point()
+pl[[2]] = pl[[2]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = percentage_gene_gc_content, y = logFC))
+pl[[2]] = pl[[2]] + scale_color_manual(values = c('green','grey','red'))
+pl[[2]] = pl[[2]] + theme(legend.position = 'top')
+
+pl[[3]] = ggplot(DE %>% 
+                    arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = AveExpr, y = logFC, color = Direction)) + geom_point()
+pl[[3]] = pl[[3]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = AveExpr, y = logFC))
+pl[[3]] = pl[[3]] + scale_color_manual(values = c('green','grey','red'))
+pl[[3]] = pl[[3]] + theme(legend.position = 'top')
+
+multiplot(plotlist = pl, cols = 3)
+```
+### Source Code
+`r thisFile`
+
+### Store files in synapse
+```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}
+# Set annotations
+all.annotations = list(
+  dataType = 'geneExpression',
+  dataSubtype = 'processed',
+  assay	 = 'rnaSeq',
+  
+  tissue	= 'anterior cingulate cortex', 
+  study = 'CMC', 
+
+  species = 'Human',
+  consortium	= 'CMC',
+   
+  analysisType	= "data normalization",
+  
+  transcriptNormalizationMethod	= 'CQN',
+  transcriptQuantificationMethod = 'featureCounts',
+  referenceSet = 'GRCh38'
+)
+
+# Code
+CODE <- Folder(name = "Differential Expression - Dx - Sex", parentId = parentId)
+CODE <- synStore(CODE)
+
+# Store residual gene expression for network analysis
+RESIDUAL.GENE_EXPRESSION %>%
+  rownameToFirstColumn('ensembl_gene_id') %>%
+  write.table(file = 'CMC_ACC_Dx_Sex_netResidualExpression.tsv', sep = '\t', row.names=F, quote=F)
+nEXP_OBJ = File('CMC_ACC_Dx_Sex_netResidualExpression.tsv', 
+                name = 'Dx_Sex Normalised, covariates removed residual expression (for network analysis)', 
+                parentId = CODE$properties$id)
+nEXP_OBJ = synStore(nEXP_OBJ, used = ALL_USED_IDs, activityName = activityName, 
+                    executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(nEXP_OBJ, annotations = all.annotations)
+
+# Store differential expression results
+write.table(DE, file = 'CMC_ACC_Dx_Sex_DiffExpression.tsv', sep = '\t', row.names=F, quote=F)
+DEXP_OBJ = File('CMC_ACC_Dx_Sex_DiffExpression.tsv', 
+                name = 'Differential Expression Results (Dx_Sex)', 
+                parentId = CODE$properties$id)
+DEXP_OBJ = synStore(DEXP_OBJ, used = ALL_USED_IDs, activityName = activityName, 
+                    executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(DEXP_OBJ, annotations = all.annotations)
+
+# Store adjusted fit linear mixed model object as RDS - Dx
+saveRDS(ADJUSTED.FIT, file = 'CMC_ACC_Dx_Sex_dream-output.rds')
+ADJ_OBJ = File('CMC_ACC_Dx_Sex_dream-output.rds',
+               name = 'Dream Output object - Dx_Sex', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store variancePartition
+saveRDS(sortCols(violin_plot), file = 'CMC_ACC_Dx_Sex_variancePartition.rds')
+ADJ_OBJ = File('CMC_ACC_Dx_Sex_variancePartition.rds',
+               name = 'Variance Partition result', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store voom object
+saveRDS(VOOM.GENE_EXPRESSION, file = 'CMC_ACC_Dx_Sex_voom.rds')
+ADJ_OBJ = File('CMC_ACC_Dx_Sex_voom.rds',
+               name = 'voom object', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store contrasts
+saveRDS(L, file = 'CMC_ACC_Dx_Sex_contrasts.rds')
+ADJ_OBJ = File('CMC_ACC_Dx_Sex_contrasts.rds',
+               name = 'contrast matrix', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store formula
+saveRDS(formula, file = 'CMC_ACC_Dx_Sex_formula.rds')
+ADJ_OBJ = File('CMC_ACC_Dx_Sex_formula.rds',
+               name = 'formula', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+```

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd
@@ -78,8 +78,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22013154"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22013153"
@@ -100,6 +99,12 @@ METADATA = downloadFile(MD_ID) %>%
 
 COVARIATES = right_join(METADATA, COVARIATES, by = c("Sample_RNA_ID" = "SampleID")) %>% 
   tibble::column_to_rownames(var = "Sample_RNA_ID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Institution", "Reported_Gender", "LibraryBatch", "Dx", "RibozeroBatch", "FlowcellBatch")

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd
@@ -31,6 +31,7 @@ library(CovariateAnalysis)
 library(edgeR)
 library(WGCNA)
 library(biomaRt)
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
 
 synLogin()
 
@@ -119,21 +120,38 @@ random_effect <- c("Institution")
 ```
 
 ### Normalisation - Sex
-
-1. Sex is chosen as the primary variable of interest (i.e., covariate adjustments is conditioned on diagnosis)
+1. Sex is chosen as the primary variable of interest
 
 ```{r iterative.normalisation, results='asis'}
 writeLines(glue::glue('Using following covariates in the model:',
                  glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
-                 ' as fixed effects and',
-                 glue::glue_collapse(random_effect, sep = ", ", last = " and "),' chosen as random effects'))
+                 ' as fixed effects.'))
+
+col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
+  dplyr::summarise_all(class) %>% 
+  tidyr::gather(variable, class)
+
+# Scale continuous variables
+covars = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0(col_type$variable[i]),
+    "numeric" = paste0('scale(', col_type$variable[i], ')')
+  )
+  })
 
 # Post adjusted formula
-formula <- glue::glue("~ ", glue::glue_collapse(adjust.covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))    
+formula <- formula(glue::glue("~", glue::glue_collapse(covars, sep = " + ")))
+design <- model.matrix(formula, COVARIATES)
 
 # Estimate voom weights with DREAM
 geneExpr = DGEList(NEW.COUNTS)
-geneExpr = edgeR::calcNormFactors(geneExpr)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
 
 VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
                                                                formula = formula,
@@ -165,8 +183,7 @@ setMethod("plot", signature(x="EList", y="missing"),
 plot(VOOM.GENE_EXPRESSION)
 
 # Fit linear model using new weights and new design
-VOOM.GENE_EXPRESSION$E = CQN.GENE_EXPRESSION
-ADJUSTED.FIT = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION,
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
                                         formula = formula,
                                         data = COVARIATES,
                                         computeResiduals = TRUE)

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd
@@ -411,7 +411,7 @@ all.annotations = list(
 )
 
 # Code
-CODE <- Folder(name = "Differential Expression - Dx - Sex", parentId = parentId)
+CODE <- Folder(name = "Differential Expression - Sex", parentId = parentId)
 CODE <- synStore(CODE)
 
 # Store residual gene expression for network analysis

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd
@@ -11,7 +11,7 @@ library(knit2synapse)
 
 synLogin()
 
-knit2synapse::createAndKnitToFolderEntity(file = "individual-cohorts/MSSM-Penn-Pitt_ACC_DE.Rmd",
+knit2synapse::createAndKnitToFolderEntity(file = "individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd",
                                  parentId ="syn22012953",
                                  folderName = "Differential Expression - Sex")
 ```
@@ -60,11 +60,11 @@ parentId = 'syn22012953';
 activityName = 'Differential Expression';
 activityDescription = 'Differential Expression - Sex';
 
-thisFileName <- 'MSSM-Penn-Pitt_ACC_DE.Rmd'
+thisFileName <- 'MSSM-Penn-Pitt_ACC_DE_Sex.Rmd'
 
 # Github link
-thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='master')
-thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/',thisFileName))
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
 ### Data download
@@ -303,7 +303,7 @@ backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
 
 # Get gene lengths
 counts = 'syn21867938'
-ALL_USED_IDs = counts
+ALL_USED_IDs = c(ALL_USED_IDs, counts)
 counts = downloadFile(counts) %>% data.frame()
 gene_lengths = counts[,c("Geneid", "Length")] %>% 
   dplyr::rename(gene_id = Geneid)
@@ -386,6 +386,8 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 
 multiplot(plotlist = pl, cols = 3)
 ```
+### Source Code
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_ACC_DE_Sex.Rmd
@@ -311,7 +311,7 @@ rm(counts)
 
 # Define biomart object
 mart <- biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL",
-                host = "uswest.ensembl.org", # Ensembl Release 99 (January 2020)
+                host = "ensembl.org", # Ensembl Release 99 (January 2020)
                 dataset = "hsapiens_gene_ensembl")
 
 # Query biomart

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Diagnosis.Rmd
@@ -329,7 +329,7 @@ rm(counts)
 
 # Define biomart object
 mart <- biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL",
-                host = "uswest.ensembl.org", # Ensembl Release 99 (January 2020)
+                host = "ensembl.org", # Ensembl Release 99 (January 2020)
                 dataset = "hsapiens_gene_ensembl")
 
 # Query biomart

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Diagnosis.Rmd
@@ -65,11 +65,11 @@ parentId = 'syn22043922';
 activityName = 'Differential Expression';
 activityDescription = 'Differential Expression - Dx';
 
-thisFileName <- 'MSSM-Penn-Pitt_DLPFC_DE.Rmd'
+thisFileName <- 'MSSM-Penn-Pitt_DLPFC_DE_Diagnosis.Rmd'
 
 # Github link
-thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='master')
-thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/',thisFileName))
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
 ### Data download
@@ -321,7 +321,7 @@ backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
 
 # Get gene lengths
 counts = 'syn21867938'
-ALL_USED_IDs = counts
+ALL_USED_IDs = c(ALL_USED_IDs, counts)
 counts = downloadFile(counts) %>% data.frame()
 gene_lengths = counts[,c("Geneid", "Length")] %>% 
   dplyr::rename(gene_id = Geneid)
@@ -403,6 +403,8 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 
 multiplot(plotlist = pl, cols = 3)
 ```
+### Source Code
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Diagnosis.Rmd
@@ -83,8 +83,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22045741"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22045729"
@@ -105,6 +104,12 @@ METADATA = downloadFile(MD_ID) %>%
 
 COVARIATES = right_join(METADATA, COVARIATES, by = c("Sample_RNA_ID" = "SampleID")) %>% 
   tibble::column_to_rownames(var = "Sample_RNA_ID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Institution", "Reported_Gender", "LibraryBatch", "Dx", "RibozeroBatch", "FlowcellBatch")

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Diagnosis.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Diagnosis.Rmd
@@ -36,6 +36,7 @@ library(synapser)
 library(knitr)
 library(githubr) # get the package from devtools::install_github('brian-bot/githubr')
 library(WGCNA)
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
 
 synLogin()
 
@@ -127,15 +128,33 @@ random_effect <- c("Institution", "Reported_Gender")
 ```{r iterative.normalisation, results='asis'}
 writeLines(glue::glue('Using following covariates in the model:',
                  glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
-                 ' as fixed effects and',
-                 glue::glue_collapse(random_effect, sep = ", ", last = " and "),' chosen as random effects'))
+                 ' as fixed effects.'))
+
+col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
+  dplyr::summarise_all(class) %>% 
+  tidyr::gather(variable, class)
+
+# Scale continuous variables
+covars = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0(col_type$variable[i]),
+    "numeric" = paste0('scale(', col_type$variable[i], ')')
+  )
+  })
 
 # Post adjusted formula
-formula <- glue::glue("~ ", glue::glue_collapse(adjust.covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))    
+formula <- formula(glue::glue("~", glue::glue_collapse(covars, sep = " + ")))
+design <- model.matrix(formula, COVARIATES)
 
 # Estimate voom weights with DREAM
 geneExpr = DGEList(NEW.COUNTS)
-geneExpr = edgeR::calcNormFactors(geneExpr)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
 
 VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
                                                                formula = formula,
@@ -167,8 +186,7 @@ setMethod("plot", signature(x="EList", y="missing"),
 plot(VOOM.GENE_EXPRESSION)
 
 # Fit linear model using new weights and new design
-VOOM.GENE_EXPRESSION$E = CQN.GENE_EXPRESSION
-ADJUSTED.FIT = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION,
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
                                         formula = formula,
                                         data = COVARIATES,
                                         computeResiduals = TRUE)

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd
@@ -121,7 +121,7 @@ ContCovariates <- c("ageOfDeath", "PMI", "RIN", "MappedReads", "IntragenicRate",
                     "EV.1", "EV.2", "EV.3", "EV.4", "EV.5")
 COVARIATES[,ContCovariates] = lapply(COVARIATES[,ContCovariates], function(x){
   x = as.numeric(as.character(gsub('[\\,\\%]','',x)))
-})c
+})
 
 # Set covariates to adjust for from model selection
 interaction <- c("Dx", "Reported_Gender")
@@ -223,7 +223,7 @@ plotVarPart(sortCols(violin_plot))
 # Residuals after normalisation
 RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
 ```
-`r formula`
+`r glue::glue_collapse(formula)`
 ### Residual calculation
 Calculate weighted residuals and add back "Dx:Sex" to the residuals
 ```{r varsToAddBack}
@@ -340,7 +340,7 @@ rm(counts)
 
 # Define biomart object
 mart <- biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL",
-                host = "uswest.ensembl.org", # Ensembl Release 99 (January 2020)
+                host = "ensembl.org", # Ensembl Release 99 (January 2020)
                 dataset = "hsapiens_gene_ensembl")
 
 # Query biomart

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd
@@ -1,0 +1,504 @@
+---
+title: "Differential Expression - MSSM-Penn-Pitt - DLPFC - Dx - Sex"
+author: "Kelsey Montgomery, Gabriel Hoffman, Thanneer Perumal"
+date: "`r date()`"
+output: html_document
+---
+
+```{r knit2synapse, eval=FALSE}
+library(synapser)
+library(knit2synapse)
+
+synLogin()
+
+knit2synapse::createAndKnitToFolderEntity(file = "individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd",
+                                 parentId ="syn22043922",
+                                 folderName = "Differential Expression - Dx - Sex")
+```
+
+```{r libs, echo=FALSE, warning=FALSE, message=FALSE, include=FALSE}
+## Load required libraries
+library(CovariateAnalysis) # get the package from devtools::install_github('th1vairam/CovariateAnalysis@dev')
+library(data.table)
+library(tidyr)
+library(plyr)
+library(dplyr)
+library(stringr)
+library(R.utils)
+library(ggplot2)
+library(limma)
+library(psych)
+library(lme4)
+library(biomaRt)
+library(variancePartition)
+library(edgeR)
+library(synapser)
+library(knitr)
+library(githubr) # get the package from devtools::install_github('brian-bot/githubr')
+library(WGCNA)
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
+
+
+synLogin()
+
+library(foreach)
+library(future)
+library(BiocParallel)
+
+# See dream documentation to customize parallel processing       http://bioconductor.org/packages/release/bioc/vignettes/variancePartition/inst/doc/dream.html#parallel-processing
+param = SnowParam((availableCores()-2)/2, "SOCK", progressbar=TRUE)
+
+register(param)
+
+options(xtable.type="html")
+
+knitr::opts_chunk$set(
+  echo=FALSE,
+  warning=FALSE,
+  message=FALSE,
+  error = FALSE,
+  tidy = FALSE,
+  cache = TRUE)
+```
+
+```{r synapse.parameters, include=FALSE, cache=FALSE}
+parentId = 'syn22043922';
+activityName = 'Differential Expression';
+activityDescription = 'Differential Expression - Dx - Sex';
+
+thisFileName <- 'MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd'
+
+# Github link
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis',thisFileName))
+```
+
+### Data download
+#### Obtain filtered and CQN normalized counts
+```{r download.data, cache=TRUE}
+downloadFile <- function(id){
+  fread(synGet(id)$path, data.table = F)
+}
+
+# Download CQN counts
+CQN_ID = "syn22045741"
+ALL_USED_IDs = c(CQN_ID)
+CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
+  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
+  data.matrix()
+  
+# Download filtered counts
+COUNTS_ID = "syn22045729"
+ALL_USED_IDs = c(ALL_USED_IDs, COUNTS_ID)
+NEW.COUNTS = downloadFile(COUNTS_ID) %>% 
+  tibble::column_to_rownames(var = "ensembl_gene_id")
+  
+# Get covariates
+COVAR_ID = "syn22045728"
+ALL_USED_IDs = c(ALL_USED_IDs, COVAR_ID)
+COVARIATES = downloadFile(COVAR_ID) 
+
+# dropped individual id 
+MD_ID = "syn16816488"
+ALL_USED_IDs = c(ALL_USED_IDs, COUNTS_ID)
+METADATA = downloadFile(MD_ID) %>% 
+  dplyr::select(Individual_ID, Sample_RNA_ID)
+
+COVARIATES = right_join(METADATA, COVARIATES, by = c("Sample_RNA_ID" = "SampleID")) %>% 
+  tibble::column_to_rownames(var = "Sample_RNA_ID")
+
+# Set variable class
+FactorCovariates <- c("Individual_ID", "Institution", "LibraryBatch", "Dx", "Reported_Gender", "RibozeroBatch", "FlowcellBatch")
+COVARIATES[,FactorCovariates] = lapply(COVARIATES[,FactorCovariates], factor)
+
+ContCovariates <- c("ageOfDeath", "PMI", "RIN", "MappedReads", "IntragenicRate", "IntronicRate", "IntergenicRate",
+                    "GenesDetected", "ExpProfEfficiency", "rRNARate", "TotalReads","AlignmentRate", 
+                    "EV.1", "EV.2", "EV.3", "EV.4", "EV.5")
+COVARIATES[,ContCovariates] = lapply(COVARIATES[,ContCovariates], function(x){
+  x = as.numeric(as.character(gsub('[\\,\\%]','',x)))
+})c
+
+# Set covariates to adjust for from model selection
+interaction <- c("Dx", "Reported_Gender")
+adjust.covars <- c("ageOfDeath", "RIN2", "RIN", "IntronicRate", "IntragenicRate")
+random_effect <- c("Institution")
+```
+
+### Normalisation - Dx*Sex
+1. Dx*Sex is chosen as the primary variable of interest
+
+```{r iterative.normalisation, results='asis'}
+writeLines(glue::glue('Using following covariates in the model:',
+                      glue::glue_collapse(interaction, sep = ", "),
+                      ', ',
+                      glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
+                      ' as fixed effects and',
+                      glue::glue_collapse(random_effect, sep = ", ", last = " and "),' chosen as random effects'))
+
+col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
+  dplyr::summarise_all(class) %>% 
+  tidyr::gather(variable, class)
+
+# Scale continuous variables
+covars = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0(col_type$variable[i]),
+    "numeric" = paste0('scale(', col_type$variable[i], ')')
+  )
+  })
+
+# Post adjusted formula
+formula <- formula(glue::glue("~ ", glue::glue_collapse(interaction, sep = "*")," + ", glue::glue_collapse(covars, sep = " + ")))
+design <- model.matrix(formula, COVARIATES)   
+
+# Estimate voom weights with DREAM
+geneExpr = DGEList(NEW.COUNTS)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
+
+VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
+                                                               formula = formula,
+                                                               data = COVARIATES,
+                                                               save.plot = TRUE)
+
+# How to plot a voom object if save.plot=TRUE
+# Set plot generic to voom result EList
+#' @export
+setMethod("plot", signature(x="EList", y="missing"),
+  function(x,  y, ...){
+    if( is.null(x$voom.xy) || is.null(x$voom.line)){
+        stop("x does not contain the trend information.\nvoom() must be run with save.plot=TRUE")
+    }
+    # points
+    df = data.frame(x = x$voom.xy$x,
+                    y = x$voom.xy$y)
+    # trend line
+    df.line = data.frame(x = x$voom.line$x,
+                        y = x$voom.line$y)
+    ggplot(df, aes(x,y)) + geom_point(size=.1) + theme_bw(15) + 
+      theme(aspect.ratio=1, plot.title = element_text(hjust = 0.5)) + 
+      geom_line(data=df.line, aes(x,y), color="red") + xlab(bquote(log[2](count + 0.5))) + 
+      ylab(expression( sqrt("standard deviation"))) + ggtitle("Voom: Mean-variance trend") + 
+      ylim(0, max(df$y))
+  }
+)
+  
+plot(VOOM.GENE_EXPRESSION)
+
+# Fit linear model using new weights and new design
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
+                                        formula = formula,
+                                        data = COVARIATES,
+                                        computeResiduals = TRUE)
+
+col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
+  dplyr::summarise_all(class) %>% 
+  tidyr::gather(variable, class)
+
+# Model categorical variables as random to report variance fractions
+formula_for_variance_fractions = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0('(1|', col_type$variable[i], ')'),
+    "numeric" = col_type$variable[i])
+  })
+
+formula_for_variance_fractions <- glue::glue("~ ", glue::glue_collapse(formula_for_variance_fractions, sep = " + "))
+
+violin_plot <- variancePartition::fitExtractVarPartModel(VOOM.GENE_EXPRESSION,
+                                                         formula = formula_for_variance_fractions,
+                                                         data = COVARIATES)
+
+plotVarPart(sortCols(violin_plot))
+
+# Residuals after normalisation
+RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
+```
+`r formula`
+### Residual calculation
+Calculate weighted residuals and add back "Dx:Sex" to the residuals
+```{r varsToAddBack}
+# Add variable of interest back to the residuals
+varsToAddIn = grep("DxOther:Reported_GenderMale", "DxSCZ:Reported_GenderMale", colnames(ADJUSTED.FIT$design), value = T)
+RESIDUAL.GENE_EXPRESSION = RESIDUAL.GENE_EXPRESSION +
+  ADJUSTED.FIT$coefficients[,varsToAddIn] %*% t(ADJUSTED.FIT$design[,varsToAddIn])
+```
+
+### Coexpression of residual expression 
+```{r coexp2, cache=FALSE, fig.height=5, fig.width=5}
+cr = cor(t(RESIDUAL.GENE_EXPRESSION))
+hist(cr, main = 'Distribution of correlation between genes', xlab = 'Correlation')
+```
+
+### Clustering residual data
+```{r decompse.normalise.data2, fig.height=8, fig.width=8, results='asis'}
+# Find principal components of expression to plot
+PC <- prcomp(RESIDUAL.GENE_EXPRESSION, scale.=T, center = T)
+
+# Plot first 4 PCs
+plotdata <- data.frame(SampleID=rownames(PC$rotation), 
+                       PC1=PC$rotation[,1], 
+                       PC2=PC$rotation[,2])
+
+plotdata <- left_join(plotdata, rownameToFirstColumn(COVARIATES, 'SampleID')) %>% 
+  dplyr::mutate(Tissue = "DLPFC")
+
+p <- ggplot(plotdata, aes(x=PC1, y=PC2))
+p <- p + geom_point(aes(color=Institution, shape=Tissue, size=ageOfDeath))
+p <- p + theme_bw() + theme(legend.position="right") + facet_grid(Tissue~., scales = 'free_y')
+p
+```
+
+```{r decompose.normalise.data2.1, fig.height=8, fig.width=12, results='asis'}
+# Eucledian tree based analysis
+COVARIATES.tmp = data.matrix(COVARIATES[,c('Dx', 'Reported_Gender', 'Institution'), drop = FALSE])
+
+tree = hclust(as.dist(t(RESIDUAL.GENE_EXPRESSION)))
+cols = WGCNA::labels2colors(COVARIATES.tmp);
+
+WGCNA::plotDendroAndColors(tree, 
+                           colors = cols, 
+                           dendroLabels = FALSE, 
+                           abHeight = 0.80, 
+                           main = "Sample dendrogram",
+                           groupLabels = colnames(COVARIATES.tmp[,c('Dx','Reported_Gender'), drop = FALSE]))
+```
+
+```{r temp1, include=F}
+dev.off()
+gc()
+```
+
+### Differential expression analysis (SCZ - Control - Other)
+Genes that are differentially expressed at an FDR <= 0.05 are:
+```{r set-formula}
+adjust.covars <- adjust.covars[!(adjust.covars %in% "RIN2")]
+formula <- glue::glue("~ 0 + Dx_Sex + ", glue::glue_collapse(adjust.covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))    
+```
+
+`r formula`
+
+Dx_Sex is 6 levels, SCZ_Female, SCZ_Male, Other_Female, Other_Male, Control_Female, Control_Male
+
+
+```{r diffExp, fig.height=10, fig.width=15}
+# Test Dx-Sex
+COVARIATES <- COVARIATES %>%
+  tibble::rownames_to_column(var = "samples") %>% 
+  tidyr::unite("Dx_Sex",
+               dplyr::all_of(c("Dx", "Reported_Gender")),
+               remove = TRUE) %>% 
+  dplyr::mutate(`Dx_Sex` = as.factor(`Dx_Sex`)) %>% 
+  tibble::column_to_rownames(var = "samples")
+
+L1 = variancePartition::getContrast(exprObj = VOOM.GENE_EXPRESSION, 
+                                   formula = formula, 
+                                   data = COVARIATES, 
+                                   coefficient = c("Dx_SexControl_Male", "Dx_SexControl_Female"))
+L2 = c(1, -1, 0, 0, -1, 1, 0, 0, 0, 0)
+L3 = c(1, -1, -1, 1, 0, 0, 0, 0, 0, 0)
+
+# Manually set comparison between SCZ+Other vs. Control 
+L = cbind(L1, L2, L3)
+
+contrast <- c(glue::glue_collapse(names(L1[L1 != 0]), "-"), 
+              glue::glue("Dx_SexSCZ_MaleDx_SexControl_Male-Dx_SexSCZ_FemaleDx_SexControl_Female"),
+              glue::glue("Dx_SexOther_MaleDx_SexControl_Male-Dx_SexOther_FemaleDx_SexControl_Female")
+)
+
+# Visualize contrast matrix
+plotContrasts(L) 
+
+# Fit contrast
+FIT.CONTR = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION,
+                                     formula = formula,
+                                     data = COVARIATES,
+                                     L = L,
+                                     suppressWarnings = TRUE)
+
+# Get background genes 
+backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
+  dplyr::mutate(id = gene_id) %>%
+  tidyr::separate(id, c('ensembl_gene_id','position'), sep = '\\.')
+
+# Get gene lengths
+counts = 'syn21867938'
+ALL_USED_IDs = c(counts, ALL_USED_IDs)
+counts = downloadFile(counts) %>% data.frame()
+gene_lengths = counts[,c("Geneid", "Length")] %>% 
+  dplyr::rename(gene_id = Geneid)
+rm(counts)
+
+# Define biomart object
+mart <- biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL",
+                host = "uswest.ensembl.org", # Ensembl Release 99 (January 2020)
+                dataset = "hsapiens_gene_ensembl")
+
+# Query biomart
+Ensemble2HGNC <- getBM(attributes = c("ensembl_gene_id", "hgnc_symbol", 
+                                      "percentage_gene_gc_content", "gene_biotype", 
+                                      "chromosome_name"),
+                       filters = "ensembl_gene_id", 
+                       values = backgroundGenes$ensembl_gene_id,
+                       mart = mart)
+
+# Get differential expression
+DE = lapply(glue::glue("L{1:3}"), function(i, FIT){
+  topTable(FIT, coef=i, number = Inf) %>%
+    rownameToFirstColumn('gene_id') %>% 
+    left_join(backgroundGenes)
+}, FIT.CONTR) 
+names(DE) <- contrast
+
+DE = DE %>% 
+  rbindlist(idcol = 'Comparison') %>%
+  dplyr::mutate(Comparison = gsub('Dx_Sex','',Comparison),
+                Direction = logFC/abs(logFC),
+                Direction = factor(Direction, c(-1,1), c('-1' = 'DOWN', '1' = 'UP')),
+                Direction = as.character(Direction)) %>%
+  tidyr::separate(Comparison, into = c('ref.state','to.state'), sep = '-') %>%
+  tidyr::unite(Comparison, `ref.state`, `to.state`, sep = '_vs_') %>%
+  left_join(Ensemble2HGNC) %>%
+  left_join(gene_lengths)
+DE$Direction[DE$adj.P.Val > 0.05 | abs(DE$logFC) < log2(1.2)] = 'NONE'
+
+tmp = DE %>%
+  dplyr::filter(adj.P.Val <= 0.05) %>%
+  dplyr::select(ensembl_gene_id, Comparison) %>%
+  group_by(Comparison) %>%
+  dplyr::summarise(FDR_0_05 = length(unique(ensembl_gene_id)))
+
+tmp1 = DE %>%
+  dplyr::filter(adj.P.Val <= 0.05, abs(logFC) >= log2(1.2)) %>%
+  dplyr::select(ensembl_gene_id, Comparison) %>%
+  group_by(Comparison) %>%
+  dplyr::summarise(FDR_0_05_FC_1.2 = length(unique(ensembl_gene_id)))
+
+kable(full_join(tmp,tmp1))
+
+p = ggplot(DE, aes(y = -log10(adj.P.Val), x = logFC, color = Direction)) + geom_point() + xlim(c(-1,1))
+p = p + scale_color_manual(values = c('green','grey','red')) + theme_bw() %+replace% theme(legend.position = 'top')
+p = p + facet_grid(.~Comparison, scales = 'fixed')
+p
+```
+
+### Associate differential expression results with gc content, gene length and average expression
+```{r associate.de, fig.height=10, fig.width=15}
+pl = list()
+pl[[1]] = ggplot(DE %>% 
+                   arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = log10(Length), y = logFC, color = Direction)) + geom_point() 
+pl[[1]] = pl[[1]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = log10(Length), y = logFC))
+pl[[1]] = pl[[1]] + scale_color_manual(values = c('green','grey','red'))
+pl[[1]] = pl[[1]] + theme(legend.position = 'top')
+
+pl[[2]] = ggplot(DE %>% 
+                   arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = percentage_gene_gc_content, y = logFC, color = Direction)) + geom_point()
+pl[[2]] = pl[[2]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = percentage_gene_gc_content, y = logFC))
+pl[[2]] = pl[[2]] + scale_color_manual(values = c('green','grey','red'))
+pl[[2]] = pl[[2]] + theme(legend.position = 'top')
+
+pl[[3]] = ggplot(DE %>% 
+                    arrange(match(Direction, c("NONE", "UP", "DOWN"))), aes(x = AveExpr, y = logFC, color = Direction)) + geom_point()
+pl[[3]] = pl[[3]] + geom_smooth(method = 'loess', inherit.aes = FALSE, aes(x = AveExpr, y = logFC))
+pl[[3]] = pl[[3]] + scale_color_manual(values = c('green','grey','red'))
+pl[[3]] = pl[[3]] + theme(legend.position = 'top')
+
+multiplot(plotlist = pl, cols = 3)
+```
+### Source Code
+`r thisFile`
+
+### Store files in synapse
+```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}
+# Set annotations
+all.annotations = list(
+  dataType = 'geneExpression',
+  dataSubtype = 'processed',
+  assay	 = 'rnaSeq',
+  
+  tissue	= 'dorsolateral prefrontal cortex', 
+  study = 'CMC', 
+
+  species = 'Human',
+  consortium	= 'CMC',
+   
+  analysisType	= "data normalization",
+  
+  transcriptNormalizationMethod	= 'CQN',
+  transcriptQuantificationMethod = 'featureCounts',
+  referenceSet = 'GRCh38'
+)
+
+# Code
+CODE <- Folder(name = "Differential Expression - Dx - Sex", parentId = parentId)
+CODE <- synStore(CODE)
+
+# Store residual gene expression for network analysis
+RESIDUAL.GENE_EXPRESSION %>%
+  rownameToFirstColumn('ensembl_gene_id') %>%
+  write.table(file = 'CMC_DLPFC_Dx_Sex_netResidualExpression.tsv', sep = '\t', row.names=F, quote=F)
+nEXP_OBJ = File('CMC_DLPFC_Dx_Sex_netResidualExpression.tsv', 
+                name = 'Dx_Sex Normalised, covariates removed residual expression (for network analysis)', 
+                parentId = CODE$properties$id)
+nEXP_OBJ = synStore(nEXP_OBJ, used = ALL_USED_IDs, activityName = activityName, 
+                    executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(nEXP_OBJ, annotations = all.annotations)
+
+# Store differential expression results
+write.table(DE, file = 'CMC_DLPFC_Dx_Sex_DiffExpression.tsv', sep = '\t', row.names=F, quote=F)
+DEXP_OBJ = File('CMC_DLPFC_Dx_Sex_DiffExpression.tsv', 
+                name = 'Differential Expression Results (Dx_Sex)', 
+                parentId = CODE$properties$id)
+DEXP_OBJ = synStore(DEXP_OBJ, used = ALL_USED_IDs, activityName = activityName, 
+                    executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(DEXP_OBJ, annotations = all.annotations)
+
+# Store adjusted fit linear mixed model object as RDS - Dx_Sex
+saveRDS(ADJUSTED.FIT, file = 'CMC_DLPFC_Dx_Sex_dream-output.rds')
+ADJ_OBJ = File('CMC_DLPFC_Dx_Sex_dream-output.rds',
+               name = 'Dream Output object - Dx_Sex', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store variancePartition
+saveRDS(sortCols(violin_plot), file = 'CMC_DLPFC_Dx_Sex_variancePartition.rds')
+ADJ_OBJ = File('CMC_DLPFC_Dx_Sex_variancePartition.rds',
+               name = 'Variance Partition result', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store voom object
+saveRDS(VOOM.GENE_EXPRESSION, file = 'CMC_DLPFC_Dx_Sex_voom.rds')
+ADJ_OBJ = File('CMC_DLPFC_Dx_Sex_voom.rds',
+               name = 'voom object', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store contrasts
+saveRDS(L, file = 'CMC_DLPFC_Dx_Sex_contrasts.rds')
+ADJ_OBJ = File('CMC_DLPFC_Dx_Sex_contrasts.rds',
+               name = 'contrast matrix', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+
+# Store formula
+saveRDS(formula, file = 'CMC_DLPFC_Dx_Sex_formula.rds')
+ADJ_OBJ = File('CMC_DLPFC_Dx_Sex_formula.rds',
+               name = 'formula', 
+               parentId = CODE$properties$id)
+ADJ_OBJ = synStore(ADJ_OBJ, used = ALL_USED_IDs, activityName = activityName,
+                   executed = thisFile, activityDescription = activityDescription)
+synSetAnnotations(ADJ_OBJ, annotations = all.annotations)
+```

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd
@@ -84,8 +84,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22045741"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22045729"
@@ -106,6 +105,12 @@ METADATA = downloadFile(MD_ID) %>%
 
 COVARIATES = right_join(METADATA, COVARIATES, by = c("Sample_RNA_ID" = "SampleID")) %>% 
   tibble::column_to_rownames(var = "Sample_RNA_ID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Institution", "LibraryBatch", "Dx", "Reported_Gender", "RibozeroBatch", "FlowcellBatch")

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd
@@ -70,7 +70,7 @@ thisFileName <- 'MSSM-Penn-Pitt_DLPFC_DE_DxSex.Rmd'
 
 # Github link
 thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
-thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis',thisFileName))
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
 ### Data download
@@ -415,7 +415,7 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 multiplot(plotlist = pl, cols = 3)
 ```
 ### Source Code
-`r thisFile`
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Sex.Rmd
@@ -36,6 +36,7 @@ library(synapser)
 library(knitr)
 library(githubr) # get the package from devtools::install_github('brian-bot/githubr')
 library(WGCNA)
+library(rctutils) # get the packages from BiocManager::install("DarwinAwardWinner/rctutils")
 
 synLogin()
 
@@ -124,20 +125,38 @@ random_effect <- c("Institution")
 ```
 
 ### Normalisation - Sex
-1. Sex is chosen as the primary variable of interest (i.e., covariate adjustments is conditioned on diagnosis)
+1. Sex is chosen as the primary variable of interest
 
 ```{r iterative.normalisation, results='asis'}
 writeLines(glue::glue('Using following covariates in the model:',
                  glue::glue_collapse(adjust.covars, sep = ", ", last = " and "),
-                 ' as fixed effects and',
-                 glue::glue_collapse(random_effect, sep = ", ", last = " and "),' chosen as random effects'))
+                 ' as fixed effects.'))
+
+col_type <- dplyr::select(COVARIATES, c(adjust.covars, random_effect)) %>%
+  dplyr::summarise_all(class) %>% 
+  tidyr::gather(variable, class)
+
+# Scale continuous variables
+covars = sapply(1:length(col_type$class), function(i){
+  switch(col_type$class[i], 
+    "factor" = paste0(col_type$variable[i]),
+    "numeric" = paste0('scale(', col_type$variable[i], ')')
+  )
+  })
 
 # Post adjusted formula
-formula <- glue::glue("~ ", glue::glue_collapse(adjust.covars, sep = " + "), " + ", glue::glue_collapse(glue::glue("(1|{random_effect})"), sep = " + "))    
+formula <- formula(glue::glue("~", glue::glue_collapse(covars, sep = " + ")))
+design <- model.matrix(formula, COVARIATES)
 
 # Estimate voom weights with DREAM
 geneExpr = DGEList(NEW.COUNTS)
-geneExpr = edgeR::calcNormFactors(geneExpr)
+
+# Extract default offset
+offset_default = edgeR::expandAsMatrix(edgeR::getOffset(geneExpr), dim(geneExpr))
+# Build custom offset from default offset and the CQN offset
+geneExpr$offset = offset_default - CQN.GENE_EXPRESSION
+# Run rctutils::voomWithOffset
+vobj_cqn_offset = rctutils::voomWithOffset(geneExpr, design)
 
 VOOM.GENE_EXPRESSION = variancePartition::voomWithDreamWeights(counts = geneExpr, 
                                                                formula = formula,
@@ -169,8 +188,7 @@ setMethod("plot", signature(x="EList", y="missing"),
 plot(VOOM.GENE_EXPRESSION)
 
 # Fit linear model using new weights and new design
-VOOM.GENE_EXPRESSION$E = CQN.GENE_EXPRESSION
-ADJUSTED.FIT = variancePartition::dream(exprObj = VOOM.GENE_EXPRESSION,
+ADJUSTED.FIT = variancePartition::dream(exprObj = vobj_cqn_offset,
                                         formula = formula,
                                         data = COVARIATES,
                                         computeResiduals = TRUE)

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Sex.Rmd
@@ -220,6 +220,7 @@ plotVarPart(sortCols(violin_plot))
 # Residuals after normalisation
 RESIDUAL.GENE_EXPRESSION = residuals(ADJUSTED.FIT, CQN.GENE_EXPRESSION)
 ```
+`r glue::glue_collapse(formula)`
 
 ### Residual calculation
 Calculate weighted residuals and add back "Sex" to the residuals
@@ -316,7 +317,7 @@ rm(counts)
 
 # Define biomart object
 mart <- biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL",
-                host = "uswest.ensembl.org", # Ensembl Release 99 (January 2020)
+                host = "ensembl.org", # Ensembl Release 99 (January 2020)
                 dataset = "hsapiens_gene_ensembl")
 
 # Query biomart

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Sex.Rmd
@@ -65,11 +65,11 @@ parentId = 'syn22043922';
 activityName = 'Differential Expression';
 activityDescription = 'Differential Expression - Sex';
 
-thisFileName <- 'MSSM-Penn-Pitt_DLPFC_DE.Rmd'
+thisFileName <- 'MSSM-Penn-Pitt_DLPFC_DE_Sex.Rmd'
 
 # Github link
-thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='master')
-thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/',thisFileName))
+thisRepo <- getRepo(repository = "CommonMindConsortium/covarr-de", ref="branch", refName='modify-cqn-implementation')
+thisFile <- getPermlink(repository = thisRepo, repositoryPath=paste0('individual-cohorts/split_by_analysis/',thisFileName))
 ```
 
 ### Data download
@@ -308,7 +308,7 @@ backgroundGenes = data.frame(gene_id = rownames(NEW.COUNTS)) %>%
 
 # Get gene lengths
 counts = 'syn21867938'
-ALL_USED_IDs = counts
+ALL_USED_IDs = c(ALL_USED_IDs, counts)
 counts = downloadFile(counts) %>% data.frame()
 gene_lengths = counts[,c("Geneid", "Length")] %>% 
   dplyr::rename(gene_id = Geneid)
@@ -390,6 +390,8 @@ pl[[3]] = pl[[3]] + theme(legend.position = 'top')
 
 multiplot(plotlist = pl, cols = 3)
 ```
+### Source Code
+[markdown file](`r thisFile`)
 
 ### Store files in synapse
 ```{r synapse.store, include=FALSE, eval=TRUE, cache=FALSE}

--- a/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Sex.Rmd
+++ b/individual-cohorts/split_by_analysis/MSSM-Penn-Pitt_DLPFC_DE_Sex.Rmd
@@ -83,8 +83,7 @@ downloadFile <- function(id){
 CQN_ID = "syn22045741"
 ALL_USED_IDs = c(CQN_ID)
 CQN.GENE_EXPRESSION = downloadFile(CQN_ID) %>% 
-  tibble::column_to_rownames(var = "ensembl_gene_id") %>% 
-  data.matrix()
+  tibble::column_to_rownames(var = "ensembl_gene_id")
   
 # Download filtered counts
 COUNTS_ID = "syn22045729"
@@ -105,6 +104,12 @@ METADATA = downloadFile(MD_ID) %>%
 
 COVARIATES = right_join(METADATA, COVARIATES, by = c("Sample_RNA_ID" = "SampleID")) %>% 
   tibble::column_to_rownames(var = "Sample_RNA_ID")
+
+# Remove ages under 17
+COVARIATES <- COVARIATES[COVARIATES$ageOfDeath >= 17,]
+NEW.COUNTS <- NEW.COUNTS[names(NEW.COUNTS) %in% rownames(COVARIATES)]
+CQN.GENE_EXPRESSION <- CQN.GENE_EXPRESSION[names(CQN.GENE_EXPRESSION) %in% rownames(COVARIATES)] %>% 
+  data.matrix()
 
 # Set variable class
 FactorCovariates <- c("Individual_ID", "Institution", "LibraryBatch", "Dx", "Reported_Gender", "RibozeroBatch", "FlowcellBatch")


### PR DESCRIPTION
This PR: 
- Removes samples ages younger than 17
- Uses `rctutils::voomWithOffset` implementation of CQN 
- Updates Provenance to point to synIds and this `modify-cqn-implementation` branch
- Saves output of formula, contrasts, voom object, violin plot, adjusted model, DE results, residuals